### PR TITLE
fix: Channel's recursive_close issue

### DIFF
--- a/src/ghoshell_moss/core/concepts/channel.py
+++ b/src/ghoshell_moss/core/concepts/channel.py
@@ -642,12 +642,9 @@ class Channel(ABC):
 
         async def recursive_close(_chan: Channel) -> None:
             children = _chan.children()
-            if len(children) == 0:
-                return
             group_stop = []
             for child in children.values():
-                if not child.is_running():
-                    group_stop.append(recursive_close(child))
+                group_stop.append(recursive_close(child))
             await asyncio.gather(*group_stop)
             if _chan.is_running():
                 await _chan.broker.close()


### PR DESCRIPTION
Fixes: #25

###  Summary
  - Fix `recursive_close` in `Channel.run_in_ctx` to always traverse all children and then close the current channel if running. 
  - This ensures a consistent, bottom-up shutdown across the entire channel tree.

### What changed
  - Removed the early return when a node has no children.
  - Removed the `if not child.is_running()` guard; always recurse into every child.

### Verification
  - run `pytest tests/channels/test_thread_channel.py::test_channel_run_in_ctx_closes_child_channels`
