### PR TITLE
fix: minor type hint in interpreter_in_ctx

### DIFF
--- a/src/ghoshell_moss/core/concepts/shell.py
+++ b/src/ghoshell_moss/core/concepts/shell.py
@@ -1,7 +1,7 @@
 import asyncio
 import contextlib
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterable
+from collections.abc import AsyncIterable, AsyncIterator
 from typing import Literal, Optional
 
 from ghoshell_container import IoCContainer
@@ -164,7 +164,7 @@ class MOSSShell(ABC):
         *,
         stream_id: Optional[str] = None,
         channel_metas: Optional[dict[ChannelFullPath, ChannelMeta]] = None,
-    ) -> Interpreter:
+    ) -> AsyncIterator[Interpreter]:
         interpreter = await self.interpreter(kind=kind, stream_id=stream_id, channel_metas=channel_metas)
         async with interpreter:
             yield interpreter


### PR DESCRIPTION

 Fix minor type hint in `interpreter_in_ctx`

### Summary

  - Correct return annotation from `Interpreter` to `AsyncIterator[Interpreter]` for the `@asynccontextmanager` method.
  - Aligns with actual usage (async with ...), resolves type-checker noise, no runtime impact

| Before | After |
| ------ | ----- |
|  <img width="566" height="222" alt="before" src="https://github.com/user-attachments/assets/941711ed-e77c-448a-99e8-05182d3be088" /> |  <img width="640" height="239" alt="after" src="https://github.com/user-attachments/assets/7c8637f8-799d-459f-95a7-77093c8b315b" /> |