### PR TITLE
fix: new_text_message() may create messages with empty contents

### DIFF
--- a/src/ghoshell_moss/message/utils.py
+++ b/src/ghoshell_moss/message/utils.py
@@ -10,6 +10,6 @@ def new_text_message(content: str, *, role: str | Role = "") -> Message:
     """
     创建一个系统消息.
     """
-    meta = MessageMeta(role=str(role))
+    meta = MessageMeta(role=role.value if isinstance(role, Role) else str(role))
     obj = Text(text=content)
-    return Message(meta=meta).as_completed([obj.to_content()])
+    return Message(meta=meta, seq="head").as_completed([obj.to_content()])

--- a/tests/channels/test_py_channel.py
+++ b/tests/channels/test_py_channel.py
@@ -219,3 +219,5 @@ async def test_py_channel_context() -> None:
         # 更新后, messages 也变更了.
         await broker.refresh_meta()
         assert len(broker.meta().context) == 2
+        assert broker.meta().context[0].contents == [{"type": "text", "data": {"text": "hello"}}]
+        assert broker.meta().context[1].contents == [{"type": "text", "data": {"text": "world"}}]

--- a/tests/channels/test_py_channel.py
+++ b/tests/channels/test_py_channel.py
@@ -4,6 +4,7 @@ from ghoshell_moss.core.concepts.channel import Channel
 from ghoshell_moss.core.concepts.command import CommandTask, PyCommand
 from ghoshell_moss.core.py_channel import PyChannel
 from ghoshell_moss.message import Message, new_text_message
+from ghoshell_moss.message.contents import Text
 
 chan = PyChannel(name="test")
 
@@ -219,5 +220,5 @@ async def test_py_channel_context() -> None:
         # 更新后, messages 也变更了.
         await broker.refresh_meta()
         assert len(broker.meta().context) == 2
-        assert broker.meta().context[0].contents == [{"type": "text", "data": {"text": "hello"}}]
-        assert broker.meta().context[1].contents == [{"type": "text", "data": {"text": "world"}}]
+        assert broker.meta().context[0].contents[0] == Text(text="hello").to_content()
+        assert broker.meta().context[1].contents[0] == Text(text="world").to_content()


### PR DESCRIPTION
Fixes: #28 

### Summary
Fix `new_text_message()` to always populate `Message.contents`

### What changed
- Fix `new_text_message()` so it constructs the message with `seq="head"` before calling `as_completed(...)`, ensuring the provided contents are actually applied.
- ITMT, Normalize role handling when role is a Role enum by using role.value.
- Add assertions in `test_py_channel_context` to verify context messages include the expected serialized text `contents`.

### Verification
- run `pytest tests/channels/test_py_channel.py::test_py_channel_context`