### PR TITLE
fix(mcp): Align MCPChannel result handling with PyChannel and improve error reporting

### DIFF
--- a/src/ghoshell_moss/compatible/mcp_channel/mcp_channel.py
+++ b/src/ghoshell_moss/compatible/mcp_channel/mcp_channel.py
@@ -5,6 +5,7 @@ from typing import Any, Generic, Optional, TypeVar
 from ghoshell_moss import CommandError, CommandErrorCode
 from ghoshell_moss.compatible.mcp_channel.utils import mcp_call_tool_result_to_message
 from ghoshell_moss.speech.volcengine_tts.protocol import Message
+from ghoshell_moss.types import Observe
 
 try:
     import mcp
@@ -247,11 +248,8 @@ class MCPChannelRuntime(AbsChannelRuntime["MCPChannel"], Generic[R]):
                     name=meta.name,
                     arguments=final_kwargs,
                 )
-                message = mcp_call_tool_result_to_message(mcp_result, name=self.name)
-                return CommandTaskResult(
-                    result=message,
-                    messages=[message],
-                )
+                # convert to moss Message
+                return mcp_call_tool_result_to_message(mcp_result, name=self.name)
             except CommandError as e:
                 raise e
             except mcp.McpError as e:
@@ -263,16 +261,22 @@ class MCPChannelRuntime(AbsChannelRuntime["MCPChannel"], Generic[R]):
 
         return _server_caller_as_command
 
-    async def execute(self, task: CommandTask[R]) -> CommandTaskResult:
+    async def execute(self, task: CommandTask[R]) -> R:
         if not self.is_running():
             raise RuntimeError("MCPChannel is not running")
         func = self._get_command_func(task.meta)
         if func is None:
             raise LookupError(f"Channel {self._name} can find command {task.meta.name}")
 
-        result: CommandTaskResult = await func(*task.args, **task.kwargs)
-        result.caller = task.caller_name()
-        return result
+        try:
+            message = await func(*task.args, **task.kwargs)
+            task.resolve(message)
+            return message
+        except CommandError as e:
+            task.fail(e)
+        except Exception as e:
+            # unknown exception, stop execute
+            raise e
 
         # --- 工具转Command的核心逻辑 --- #
 

--- a/src/ghoshell_moss/compatible/mcp_channel/mcp_channel.py
+++ b/src/ghoshell_moss/compatible/mcp_channel/mcp_channel.py
@@ -4,6 +4,7 @@ from typing import Any, Generic, Optional, TypeVar
 
 from ghoshell_moss import CommandError, CommandErrorCode
 from ghoshell_moss.compatible.mcp_channel.utils import mcp_call_tool_result_to_message
+from ghoshell_moss.speech.volcengine_tts.protocol import Message
 
 try:
     import mcp
@@ -21,6 +22,7 @@ from ghoshell_moss.core.concepts.command import (
     CommandDeltaType,
     CommandMeta,
     CommandTask,
+    CommandTaskResult,
     CommandTaskState,
     CommandWrapper,
 )
@@ -239,8 +241,13 @@ class MCPChannelRuntime(AbsChannelRuntime["MCPChannel"], Generic[R]):
                     name=meta.name,
                     arguments=final_kwargs,
                 )
-                # convert to moss Message
-                return mcp_call_tool_result_to_message(mcp_result, name=self.name)
+                message = mcp_call_tool_result_to_message(mcp_result, name=self.name)
+                return CommandTaskResult(
+                    result=message,
+                    messages=[message],
+                )
+            except CommandError as e:
+                raise e
             except mcp.McpError as e:
                 raise CommandError(code=CommandErrorCode.FAILED.value, message=f"MCP call failed: {str(e)}") from e
             except Exception as e:
@@ -250,13 +257,16 @@ class MCPChannelRuntime(AbsChannelRuntime["MCPChannel"], Generic[R]):
 
         return _server_caller_as_command
 
-    async def execute(self, task: CommandTask[R]) -> R:
+    async def execute(self, task: CommandTask[R]) -> CommandTaskResult:
         if not self.is_running():
             raise RuntimeError("MCPChannel is not running")
         func = self._get_command_func(task.meta)
         if func is None:
             raise LookupError(f"Channel {self._name} can find command {task.meta.name}")
-        return await func(*task.args, **task.kwargs)
+
+        result: CommandTaskResult = await func(*task.args, **task.kwargs)
+        result.caller = task.caller_name()
+        return result
 
         # --- 工具转Command的核心逻辑 --- #
 

--- a/src/ghoshell_moss/compatible/mcp_channel/mcp_channel.py
+++ b/src/ghoshell_moss/compatible/mcp_channel/mcp_channel.py
@@ -188,9 +188,15 @@ class MCPChannelRuntime(AbsChannelRuntime["MCPChannel"], Generic[R]):
                         )
                 else:  # schema_param_count > 1
                     if not (param_count == 1 or required_schema_param_count <= param_count <= schema_param_count):
+                        message = f"MCP tool: invalid parameters, "
+                        if required_schema_param_count > param_count:
+                            message += f"too few parameters passed: (pass:{param_count}, required:{required_schema_param_count}), "
+                        elif param_count > schema_param_count:
+                            message += f"too many parameters passed: (pass:{param_count}, schema:{schema_param_count}), "
+                        message += f'args={args}, kwargs={kwargs}'
                         raise CommandError(
                             code=CommandErrorCode.VALUE_ERROR.value,
-                            message=f"MCP tool: invalid parameters, invalid, args={args}, kwargs={kwargs}",
+                            message=message,
                         )
                     if param_count == 1:
                         if len(args) == 1:

--- a/tests/mcp_channel/test_mcp_channel.py
+++ b/tests/mcp_channel/test_mcp_channel.py
@@ -10,7 +10,7 @@ from mcp.client.stdio import stdio_client
 from ghoshell_moss import CommandError
 from ghoshell_moss.compatible.mcp_channel.mcp_channel import MCPChannel
 from ghoshell_moss.compatible.mcp_channel.types import MCPCallToolResultAddition
-from ghoshell_moss.core.concepts.command import CommandTaskResult, CommandErrorCode
+from ghoshell_moss.core.concepts.command import CommandTaskResult, CommandErrorCode, BaseCommandTask
 from ghoshell_moss.message import Message
 
 
@@ -155,7 +155,10 @@ async def test_mcp_channel_exception():
                 assert exc_info.value.code == CommandErrorCode.FAILED.value
                 assert "MCP tool: call failed" in exc_info.value.message
                 # mcp.ClientSession call_tool
-                assert "Field required [type=missing, input_value={'a': 2, 'b': 2, 'c': 3}, input_type=dict]" in exc_info.value.message
+                assert (
+                    "Field required [type=missing, input_value={'a': 2, 'b': 2, 'c': 3}, input_type=dict]"
+                    in exc_info.value.message
+                )
 
                 available_test_cmd = runtime.get_command("add")
                 assert available_test_cmd is not None
@@ -189,3 +192,84 @@ async def test_mcp_channel_exception():
                 assert exc_info.value.code == CommandErrorCode.VALUE_ERROR.value
                 assert "invalid parameters" in exc_info.value.message.lower()
                 assert "too few parameters passed" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_mcp_channel_execute():
+    exit_stack = AsyncExitStack()
+    async with exit_stack:
+        read_stream, write_stream = await exit_stack.enter_async_context(
+            stdio_client(
+                StdioServerParameters(
+                    command=sys.executable, args=[join(dirname(__file__), "helper/mcp_server_demo.py")], env=None
+                )
+            )
+        )
+        session = ClientSession(read_stream, write_stream)
+        async with session:
+            await session.initialize()
+            tool_res = await session.list_tools()
+            assert tool_res is not None
+
+            mcp_channel = MCPChannel(
+                name="mcp",
+                description="MCP channel",
+                mcp_client=session,
+            )
+
+            async with mcp_channel.bootstrap() as runtime:
+                add_cmd = runtime.get_command("add")
+                assert add_cmd is not None
+
+                task = BaseCommandTask.from_command(
+                    add_cmd,
+                    chan_="mcp",
+                    args=(1, 2),
+                )
+
+                task_result: CommandTaskResult = await runtime.execute(task)
+                assert task_result is not None
+                assert task_result.result is not None
+                assert task_result.caller == task.caller_name()
+                assert len(task_result.messages) == 1
+
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                assert mcp_call_tool_result.isError is False
+                assert mcp_call_tool_result.structuredContent["result"] == 3
+
+                bar_cmd = runtime.get_command("bar")
+                assert bar_cmd is not None
+
+                task = BaseCommandTask.from_command(
+                    bar_cmd,
+                    chan_="mcp",
+                    kwargs={"s": "hello"},
+                )
+
+                task_result: CommandTaskResult = await runtime.execute(task)
+                assert task_result is not None
+                assert task_result.result is not None
+                assert task_result.caller == task.caller_name()
+                assert len(task_result.messages) == 1
+
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                assert mcp_call_tool_result.isError is False
+                assert mcp_call_tool_result.structuredContent["result"] == 5
+
+                foo_cmd = runtime.get_command("foo")
+                assert foo_cmd is not None
+
+                task = BaseCommandTask.from_command(
+                    foo_cmd,
+                    chan_="mcp",
+                    kwargs={"text__": json.dumps({"a": 10, "b": {"i": 20}})},
+                )
+
+                task_result: CommandTaskResult = await runtime.execute(task)
+                assert task_result is not None
+                assert task_result.result is not None
+                assert task_result.caller == task.caller_name()
+
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                assert mcp_call_tool_result.isError is False
+                assert mcp_call_tool_result.structuredContent["result"] == 30

--- a/tests/mcp_channel/test_mcp_channel.py
+++ b/tests/mcp_channel/test_mcp_channel.py
@@ -10,14 +10,11 @@ from mcp.client.stdio import stdio_client
 from ghoshell_moss import CommandError
 from ghoshell_moss.compatible.mcp_channel.mcp_channel import MCPChannel
 from ghoshell_moss.compatible.mcp_channel.types import MCPCallToolResultAddition
+from ghoshell_moss.core.concepts.command import CommandTaskResult, CommandErrorCode
 from ghoshell_moss.message import Message
 
 
 def get_mcp_call_tool_result(message: Message) -> MCPCallToolResultAddition:
-    """
-    测试用例里应该只有一个 MCPStructuredContent
-    """
-
     return MCPCallToolResultAddition.read(message)
 
 
@@ -44,89 +41,151 @@ async def test_mcp_channel_baseline():
                 mcp_client=session,
             )
 
-            async with mcp_channel.bootstrap() as client:
-                commands = list(client.own_commands().values())
-                assert len(commands) > 0
+            async with mcp_channel.bootstrap() as runtime:
+                commands = list(runtime.own_commands().values())
+                assert len(commands) == 4
 
-                # print('')
-                # for i, cmd in enumerate(commands):
-                #     print(f"{i}: {cmd.name()} {cmd.meta().model_dump_json()}")
-
-                available_test_cmd = client.get_command("add")
+                available_test_cmd = runtime.get_command("add")
                 assert available_test_cmd is not None
 
-                # args
-                res: Message = await available_test_cmd(1, 2)
-                mcp_call_tool_result = get_mcp_call_tool_result(res)
+                task_result: CommandTaskResult = await available_test_cmd(1, 2)
+                assert task_result.result is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                assert task_result.caller is None
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                # kwargs
-                res: Message = await available_test_cmd(x=1, y=2)
-                mcp_call_tool_result = get_mcp_call_tool_result(res)
+                task_result: CommandTaskResult = await available_test_cmd(x=1, y=2)
+                assert task_result.result is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                # args + kwargs
-                res: Message = await available_test_cmd(1, y=2)
-                mcp_call_tool_result = get_mcp_call_tool_result(res)
+                task_result: CommandTaskResult = await available_test_cmd(1, y=2)
+                assert task_result.result is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                # args, default
-                # 无法区分第一个参数是原始函数还是text__
-                res: Message = await available_test_cmd(1)
-                mcp_call_tool_result = get_mcp_call_tool_result(res)
+                task_result: CommandTaskResult = await available_test_cmd(1)
+                assert task_result.result is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                # kwargs, default
-                res: Message = await available_test_cmd(x=1)
-                mcp_call_tool_result = get_mcp_call_tool_result(res)
+                task_result: CommandTaskResult = await available_test_cmd(x=1)
+                assert task_result.result is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                # text__
                 text__: str = json.dumps({"x": 1, "y": 2})
-                res: Message = await available_test_cmd(text__=text__)
-                mcp_call_tool_result = get_mcp_call_tool_result(res)
+                task_result: CommandTaskResult = await available_test_cmd(text__=text__)
+                assert task_result.result is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
                 assert mcp_call_tool_result.isError is False
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                # args: text__
-                res: Message = await available_test_cmd(text__)
-                mcp_call_tool_result = get_mcp_call_tool_result(res)
+                task_result: CommandTaskResult = await available_test_cmd(text__)
+                assert task_result.result is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
                 assert mcp_call_tool_result.isError is False
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                # text__, default
                 text__: str = json.dumps({"x": 1})
-                res: Message = await available_test_cmd(text__=text__)
-                mcp_call_tool_result = get_mcp_call_tool_result(res)
+                task_result: CommandTaskResult = await available_test_cmd(text__=text__)
+                assert task_result.result is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
                 assert mcp_call_tool_result.isError is False
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                # foo
-                available_test_cmd = client.get_command("foo")
+                available_test_cmd = runtime.get_command("foo")
                 assert available_test_cmd is not None
 
-                # text__, default
                 text__: str = json.dumps({"a": 1, "b": {"i": 2}})
-                res: Message = await available_test_cmd(text__=text__)
-                mcp_call_tool_result = get_mcp_call_tool_result(res)
+                task_result: CommandTaskResult = await available_test_cmd(text__=text__)
+                assert task_result.result is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
                 assert mcp_call_tool_result.isError is False
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                available_test_cmd = client.get_command("bar")
+                available_test_cmd = runtime.get_command("bar")
                 assert available_test_cmd is not None
 
-                # kwargs
-                res: Message = await available_test_cmd(s="aaa")
-                mcp_call_tool_result = get_mcp_call_tool_result(res)
+                task_result: CommandTaskResult = await available_test_cmd(s="aaa")
+                assert task_result.result is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
                 assert mcp_call_tool_result.isError is False
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                # args,
-                with pytest.raises(CommandError):
+
+@pytest.mark.asyncio
+async def test_mcp_channel_exception():
+    exit_stack = AsyncExitStack()
+    async with exit_stack:
+        read_stream, write_stream = await exit_stack.enter_async_context(
+            stdio_client(
+                StdioServerParameters(
+                    command=sys.executable, args=[join(dirname(__file__), "helper/mcp_server_demo.py")], env=None
+                )
+            )
+        )
+        session = ClientSession(read_stream, write_stream)
+        async with session:
+            await session.initialize()
+            tool_res = await session.list_tools()
+            assert tool_res is not None
+
+            mcp_channel = MCPChannel(
+                name="mcp",
+                description="MCP channel",
+                mcp_client=session,
+            )
+
+            async with mcp_channel.bootstrap() as runtime:
+                available_test_cmd = runtime.get_command("bar")
+                assert available_test_cmd is not None
+                with pytest.raises(CommandError) as exc_info:
                     await available_test_cmd("aaa")
+                assert exc_info.value.code == CommandErrorCode.VALUE_ERROR.value
+                # only 1 arg, default cast to 'text__'
+                assert "invalid `text__` parameter format" in exc_info.value.message
+                assert "INVALID JSON schema" in exc_info.value.message
 
-                available_test_cmd = client.get_command("multi")
+                available_test_cmd = runtime.get_command("multi")
                 assert available_test_cmd is not None
-
-                with pytest.raises(CommandError):
+                with pytest.raises(CommandError) as exc_info:
+                    # missing arg "d"
                     await available_test_cmd(1, 2, a=2, c=3)
+                assert exc_info.value.code == CommandErrorCode.FAILED.value
+                assert "MCP tool: call failed" in exc_info.value.message
+                # mcp.ClientSession call_tool
+                assert "Field required [type=missing, input_value={'a': 2, 'b': 2, 'c': 3}, input_type=dict]" in exc_info.value.message
+
+                available_test_cmd = runtime.get_command("add")
+                assert available_test_cmd is not None
+                with pytest.raises(CommandError) as exc_info:
+                    await available_test_cmd("invalid_json")
+                assert exc_info.value.code == CommandErrorCode.VALUE_ERROR.value
+                assert "invalid `text__` parameter format" in exc_info.value.message
+                assert "INVALID JSON schema" in exc_info.value.message
+
+                available_test_cmd = runtime.get_command("foo")
+                assert available_test_cmd is not None
+                with pytest.raises(CommandError) as exc_info:
+                    await available_test_cmd(12345)
+                assert exc_info.value.code == CommandErrorCode.VALUE_ERROR.value
+                assert 'invalid "text__" type' in exc_info.value.message
+                # json.loads() -> TypeError
+                assert "the JSON object must be str, bytes or bytearray, not int" in exc_info.value.message
+
+                available_test_cmd = runtime.get_command("bar")
+                assert available_test_cmd is not None
+                with pytest.raises(CommandError) as exc_info:
+                    await available_test_cmd(s="aaa", extra_param="extra")
+                assert exc_info.value.code == CommandErrorCode.VALUE_ERROR.value
+                assert "invalid parameters" in exc_info.value.message.lower()
+                assert "too many parameters passed" in exc_info.value.message
+
+                available_test_cmd = runtime.get_command("multi")
+                assert available_test_cmd is not None
+                with pytest.raises(CommandError) as exc_info:
+                    await available_test_cmd(a=1, b=2)
+                assert exc_info.value.code == CommandErrorCode.VALUE_ERROR.value
+                assert "invalid parameters" in exc_info.value.message.lower()
+                assert "too few parameters passed" in exc_info.value.message

--- a/tests/mcp_channel/test_mcp_channel.py
+++ b/tests/mcp_channel/test_mcp_channel.py
@@ -10,7 +10,7 @@ from mcp.client.stdio import stdio_client
 from ghoshell_moss import CommandError
 from ghoshell_moss.compatible.mcp_channel.mcp_channel import MCPChannel
 from ghoshell_moss.compatible.mcp_channel.types import MCPCallToolResultAddition
-from ghoshell_moss.core.concepts.command import CommandTaskResult, CommandErrorCode, BaseCommandTask
+from ghoshell_moss.core.concepts.command import CommandErrorCode, BaseCommandTask, CommandTaskResult
 from ghoshell_moss.message import Message
 
 
@@ -48,49 +48,48 @@ async def test_mcp_channel_baseline():
                 available_test_cmd = runtime.get_command("add")
                 assert available_test_cmd is not None
 
-                task_result: CommandTaskResult = await available_test_cmd(1, 2)
-                assert task_result.result is not None
-                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
-                assert task_result.caller is None
+                message: Message = await available_test_cmd(1, 2)
+                assert message is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(message)
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                task_result: CommandTaskResult = await available_test_cmd(x=1, y=2)
-                assert task_result.result is not None
-                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                message: Message = await available_test_cmd(x=1, y=2)
+                assert message is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(message)
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                task_result: CommandTaskResult = await available_test_cmd(1, y=2)
-                assert task_result.result is not None
-                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                message: Message = await available_test_cmd(1, y=2)
+                assert message is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(message)
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                task_result: CommandTaskResult = await available_test_cmd(1)
-                assert task_result.result is not None
-                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                message: Message = await available_test_cmd(1)
+                assert message is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(message)
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                task_result: CommandTaskResult = await available_test_cmd(x=1)
-                assert task_result.result is not None
-                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                message: Message = await available_test_cmd(x=1)
+                assert message is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(message)
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
                 text__: str = json.dumps({"x": 1, "y": 2})
-                task_result: CommandTaskResult = await available_test_cmd(text__=text__)
-                assert task_result.result is not None
-                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                message: Message = await available_test_cmd(text__=text__)
+                assert message is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(message)
                 assert mcp_call_tool_result.isError is False
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
-                task_result: CommandTaskResult = await available_test_cmd(text__)
-                assert task_result.result is not None
-                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                message: Message = await available_test_cmd(text__)
+                assert message is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(message)
                 assert mcp_call_tool_result.isError is False
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
                 text__: str = json.dumps({"x": 1})
-                task_result: CommandTaskResult = await available_test_cmd(text__=text__)
-                assert task_result.result is not None
-                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                message: Message = await available_test_cmd(text__=text__)
+                assert message is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(message)
                 assert mcp_call_tool_result.isError is False
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
@@ -98,18 +97,18 @@ async def test_mcp_channel_baseline():
                 assert available_test_cmd is not None
 
                 text__: str = json.dumps({"a": 1, "b": {"i": 2}})
-                task_result: CommandTaskResult = await available_test_cmd(text__=text__)
-                assert task_result.result is not None
-                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                message: Message = await available_test_cmd(text__=text__)
+                assert message is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(message)
                 assert mcp_call_tool_result.isError is False
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
                 available_test_cmd = runtime.get_command("bar")
                 assert available_test_cmd is not None
 
-                task_result: CommandTaskResult = await available_test_cmd(s="aaa")
-                assert task_result.result is not None
-                mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
+                message: Message = await available_test_cmd(s="aaa")
+                assert message is not None
+                mcp_call_tool_result = get_mcp_call_tool_result(message)
                 assert mcp_call_tool_result.isError is False
                 assert mcp_call_tool_result.structuredContent["result"] == 3
 
@@ -227,11 +226,10 @@ async def test_mcp_channel_execute():
                     args=(1, 2),
                 )
 
-                task_result: CommandTaskResult = await runtime.execute(task)
+                await runtime.execute(task)
+                task_result = task.task_result()
                 assert task_result is not None
                 assert task_result.result is not None
-                assert task_result.caller == task.caller_name()
-                assert len(task_result.messages) == 1
 
                 mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
                 assert mcp_call_tool_result.isError is False
@@ -246,11 +244,10 @@ async def test_mcp_channel_execute():
                     kwargs={"s": "hello"},
                 )
 
-                task_result: CommandTaskResult = await runtime.execute(task)
+                await runtime.execute(task)
+                task_result = task.task_result()
                 assert task_result is not None
                 assert task_result.result is not None
-                assert task_result.caller == task.caller_name()
-                assert len(task_result.messages) == 1
 
                 mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
                 assert mcp_call_tool_result.isError is False
@@ -265,11 +262,121 @@ async def test_mcp_channel_execute():
                     kwargs={"text__": json.dumps({"a": 10, "b": {"i": 20}})},
                 )
 
-                task_result: CommandTaskResult = await runtime.execute(task)
+                await runtime.execute(task)
+                task_result = task.task_result()
                 assert task_result is not None
                 assert task_result.result is not None
-                assert task_result.caller == task.caller_name()
 
                 mcp_call_tool_result = get_mcp_call_tool_result(task_result.result)
                 assert mcp_call_tool_result.isError is False
                 assert mcp_call_tool_result.structuredContent["result"] == 30
+
+
+@pytest.mark.asyncio
+async def test_mcp_channel_execute_exception():
+    exit_stack = AsyncExitStack()
+    async with exit_stack:
+        read_stream, write_stream = await exit_stack.enter_async_context(
+            stdio_client(
+                StdioServerParameters(
+                    command=sys.executable, args=[join(dirname(__file__), "helper/mcp_server_demo.py")], env=None
+                )
+            )
+        )
+        session = ClientSession(read_stream, write_stream)
+        async with session:
+            await session.initialize()
+            tool_res = await session.list_tools()
+            assert tool_res is not None
+
+            mcp_channel = MCPChannel(
+                name="mcp",
+                description="MCP channel",
+                mcp_client=session,
+            )
+
+            async with mcp_channel.bootstrap() as runtime:
+                # Test 1: bar command with invalid JSON (single arg "aaa")
+                bar_cmd = runtime.get_command("bar")
+                assert bar_cmd is not None
+
+                task = BaseCommandTask.from_command(
+                    bar_cmd,
+                    chan_="mcp",
+                    args=("aaa",),  # invalid JSON
+                )
+
+                await runtime.execute(task)
+                assert task.errcode == CommandErrorCode.VALUE_ERROR.value
+                assert "invalid `text__` parameter format" in task.errmsg
+                assert "INVALID JSON schema" in task.errmsg
+
+                # Test 2: multi command with missing required arg "d"
+                multi_cmd = runtime.get_command("multi")
+                assert multi_cmd is not None
+
+                task = BaseCommandTask.from_command(
+                    multi_cmd,
+                    chan_="mcp",
+                    args=(1, 2),
+                    kwargs={"a": 2, "c": 3},  # missing "d"
+                )
+
+                await runtime.execute(task)
+                assert task.errcode == CommandErrorCode.FAILED.value
+                assert "MCP tool: call failed" in task.errmsg
+                assert "Field required" in task.errmsg
+
+                # Test 3: add command with invalid JSON string
+                add_cmd = runtime.get_command("add")
+                assert add_cmd is not None
+
+                task = BaseCommandTask.from_command(
+                    add_cmd,
+                    chan_="mcp",
+                    args=("invalid_json",),
+                )
+
+                await runtime.execute(task)
+                assert task.errcode == CommandErrorCode.VALUE_ERROR.value
+                assert "invalid `text__` parameter format" in task.errmsg
+                assert "INVALID JSON schema" in task.errmsg
+
+                # Test 4: foo command with non-string arg (int)
+                foo_cmd = runtime.get_command("foo")
+                assert foo_cmd is not None
+
+                task = BaseCommandTask.from_command(
+                    foo_cmd,
+                    chan_="mcp",
+                    args=(12345,),  # should be string for JSON parsing
+                )
+
+                await runtime.execute(task)
+                assert task.errcode == CommandErrorCode.VALUE_ERROR.value
+                assert 'invalid "text__" type' in task.errmsg
+                assert "the JSON object must be str, bytes or bytearray, not int" in task.errmsg
+
+                # Test 5: bar command with too many parameters
+                task = BaseCommandTask.from_command(
+                    bar_cmd,
+                    chan_="mcp",
+                    kwargs={"s": "aaa", "extra_param": "extra"},
+                )
+
+                await runtime.execute(task)
+                assert task.errcode == CommandErrorCode.VALUE_ERROR.value
+                assert "invalid parameters" in task.errmsg.lower()
+                assert "too many parameters passed" in task.errmsg
+
+                # Test 6: multi command with too few parameters
+                task = BaseCommandTask.from_command(
+                    multi_cmd,
+                    chan_="mcp",
+                    kwargs={"a": 1, "b": 2},  # missing required params
+                )
+
+                await runtime.execute(task)
+                assert task.errcode == CommandErrorCode.VALUE_ERROR.value
+                assert "invalid parameters" in task.errmsg.lower()
+                assert "too few parameters passed" in task.errmsg


### PR DESCRIPTION
## Summary
Aligns MCPChannel result/error handling with PyChannel pattern and fixes error code overwriting bug.

## Changes
- **Bug Fixes**: 
  - Fixed VALUE_ERROR being overwritten by FAILED during parameter parsing
  - Aligned CommandTaskResult handling with PyChannel (return raw results, let task framework wrap)
  
- **Improvements**:
  - Use `task.fail()` for consistent error state management
  - Better MCP parameter validation error messages

- **Tests**: 
  - Restructured test suite (baseline + exception tests)
  - Added `test_mcp_channel_execute()` for task-based execution
  - Added `test_mcp_channel_execute_exception()` covering 6 error scenarios
 
## Files Changed
- `src/ghoshell_moss/compatible/mcp_channel/mcp_channel.py`
- `tests/mcp_channel/test_mcp_channel.py`