### PR TITLE
fix: fractal 端到端验证修复 — CLI 对齐抽象 API + shell 缓存失效 coding by mimo-v2.5-pro

### DIFF
--- a/.ai_partners/features/workstreams/2026/05/zenoh-fractal/FEATURE.md
+++ b/.ai_partners/features/workstreams/2026/05/zenoh-fractal/FEATURE.md
@@ -8,7 +8,7 @@ id: zenoh-fractal
 milestone: beta
 priority: P0
 status: in-progress
-status_note: Hub/Provider 分离完成，发现机制升级为 subscriber + re-put，单测 5/5 全绿。TUI 改为 IoC 发现。MossRuntime 新增 get_fractal_hub()。待端到端验证。
+status_note: Hub/Provider 分离完成，发现机制升级为 subscriber + re-put，单测 5/5 全绿。TUI 改为 IoC 发现。MossRuntime 新增 get_fractal_hub()。修复 /moss.static() 缓存导致 fractal channel 不可见的 bug。待端到端验证。
 title: Zenoh Fractal — Hub/Provider 分离与反向注册
 updated: '2026-05-14'
 ---
@@ -133,6 +133,7 @@ Providers (Channel):   {prefix}/{hub_name}/providers/{node_name}
 | **`MossRuntime.get_fractal_hub()` API 新增** | ✅ done |
 | **`FractalServeState` IoC 发现重构** | ✅ done |
 | **`ZenohFractalHubProvider` 注册到 workspace stubs** | ✅ done |
+| **`/moss.static()` 缓存 bug 修复** | ✅ done |
 
 ### 待完成
 
@@ -249,7 +250,53 @@ Providers (Channel):   {prefix}/{hub_name}/providers/{node_name}
 - 如果未来有不需要 IoC 的 MossRuntime 实现，它仍可 override 返回 None
 - 与 `.container`、`.session` 的默认实现模式一致
 
-### 9. FractalServeState 从创建者变为观测者 (2026-05-14)
+### 9. `moss-as-fractal` CLI 对齐抽象 API (2026-05-14)
+
+**问题**: `moss_as_fractal.py` 手动创建 `ZenohSessionFractalNodeProvider` 实例、
+配置 zenoh session、管理生命周期，与 `FractalNodeProvider` ABC 的设计重复。
+
+**改动**:
+
+1. **`moss_as_fractal.py` 简化** — 删除手动实现，改用 `host.provide_moss_as_fractal(provider=None)`。
+   Host 自动从 IoC 容器发现 `FractalNodeProvider`，CLI 只负责环境配置和启动。
+
+2. **新增 `ZenohFractalNodeProviderProvider`** — IoC Provider 类，
+   从 workspace config (`zenoh_config_fractal.json5`) 自动创建 `ZenohSessionFractalNodeProvider`。
+   与 `ZenohFractalHubProvider` 对称。
+
+3. **providers.py 注册** — stubs 和 `.moss_ws`、`.test_ws` 的 `providers.py` 均添加
+   `fractal_node_provider = ZenohFractalNodeProviderProvider()`。
+
+**理由**: CLI 不应绕过 IoC 体系手动创建实例。
+`provide_moss_as_fractal()` 是 MossHost 的标准 API，自动发现 + 生命周期管理。
+
+### 10. `/moss.static()` 缓存失效修复 (2026-05-14)
+
+**现象**: Hub 启动且节点连接后，`/moss.static()` 不显示 fractal channel 和 `open_node` 命令。
+但 `<moss:open_node name="moss_provider"/>` 实际可以执行。
+
+**根因**: 两层缓存导致 `/moss.static()` 返回启动时的陈旧快照：
+
+1. **`_moss_static_cache` 永不失效** — `static_messages()` 在 shell 启动时首次调用，
+   此时 Hub 未启动，fractal channel 的 `is_available()=False`。
+   结果缓存后永不刷新（`_refresh_moss_static` 默认 `False`）。
+
+2. **`_last_channel_metas_refreshed_at` 永为 0** — 初始化为 0 但从未更新，
+   导致 `channel_metas()` 的 0.5s 时间检查永远返回陈旧缓存。
+
+**修复** (3 个文件):
+
+| 文件 | 改动 |
+|------|------|
+| `core/ctml/shell/ctml_shell.py` `refresh_metas()` | 同时清除 `_moss_static_cache` |
+| `core/ctml/shell/ctml_shell.py` `channel_metas()` | 设置缓存后更新 `_last_channel_metas_refreshed_at` |
+| `host/repl/inspector_moss_runtime.py` `static()` | 改为 async，先调 `moss_refresh_metas()` 再取 static |
+| `host/moss_runtime.py` | 新增 `moss_refresh_metas()` 公共方法 |
+
+**效果**: `/moss.static()` 现在先刷新 metas（重新评估所有 channel 的 `is_available()`），
+再生成 static 输出。fractal channel 和已 open 的节点 channel 正确显示。
+
+### 11. FractalServeState 从创建者变为观测者 (2026-05-14)
 
 **决策**: `FractalServeState` 不再自己创建 Hub 和管理 channel，改为从 `runtime.get_fractal_hub()` 发现已有 Hub。
 
@@ -284,8 +331,10 @@ Providers (Channel):   {prefix}/{hub_name}/providers/{node_name}
 - Hub/Provider 实现: `src/ghoshell_moss/host/fractal/zenoh_fractal.py`
 - IoC Provider: `src/ghoshell_moss/host/fractal/zenoh_fractal.py` (ZenohFractalHubProvider)
 - Key space 与 Cell: `src/ghoshell_moss/host/fractal/_base.py`
-- Matrix 集成: `src/ghoshell_moss/host/moss_runtime.py` (__aenter__)
+- Matrix 集成: `src/ghoshell_moss/host/moss_runtime.py` (__aenter__, moss_refresh_metas)
 - REPL State: `src/ghoshell_moss/host/repl/fractal_serve_state.py`
+- REPL Inspector: `src/ghoshell_moss/host/repl/inspector_moss_runtime.py`
+- Shell 缓存逻辑: `src/ghoshell_moss/core/ctml/shell/ctml_shell.py`
 - CLI 入口: `src/ghoshell_moss/cli/moss_as_fractal.py`
 - 环境注册 (stubs): `src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/providers.py`
 - Hub 配置: `src/ghoshell_moss/host/stubs/workspace/configs/zenoh_config_fractal_hub.json5`

--- a/src/ghoshell_moss/cli/moss_as_fractal.py
+++ b/src/ghoshell_moss/cli/moss_as_fractal.py
@@ -13,9 +13,7 @@ from datetime import datetime
 import click
 
 from ghoshell_moss.host import Host
-from ghoshell_moss.host.fractal.zenoh_fractal import ZenohSessionFractalNodeProvider
 from ghoshell_moss.core.blueprint.environment import Environment
-from ghoshell_moss.core.blueprint.matrix import Matrix
 
 
 class ClickHandler(logging.Handler):
@@ -48,10 +46,10 @@ def main(mode: str, session_scope: str, transport: str | None):
     if session_scope:
         env.set_session_scope(session_scope)
 
-    moss_host = Host(env=env)
-    moss_runtime = moss_host.run()
+    host = Host(env=env)
 
-    _logger = moss_host.matrix().logger
+    # 配置日志输出
+    _logger = host.matrix().logger
     if isinstance(_logger, logging.Logger):
         _handler = ClickHandler()
         _handler.setFormatter(logging.Formatter(
@@ -60,50 +58,22 @@ def main(mode: str, session_scope: str, transport: str | None):
         _logger.addHandler(_handler)
         _logger.setLevel(logging.DEBUG)
 
-    async def run_fractal(_matrix: Matrix):
-        workspace = moss_host.matrix().workspace
-        config_path = workspace.configs().abspath() / "zenoh_config_fractal_hub.json5"
-        if not config_path.exists():
-            raise FileNotFoundError(
-                f"Fractal zenoh config not found: {config_path}\n"
-                f"请确保 workspace 中存在 zenoh_config_fractal_hub.json5"
-            )
-
-        provider = ZenohSessionFractalNodeProvider(
-            hub_name=env.meta_config.name,
-            zenoh_conf_file=config_path,
-            logger=moss_host.matrix().logger,
-            transport_endpoint=transport,
-        )
-
-        async with provider:
-            await provider.provide(moss_runtime)
-
-            click.echo("")
-            click.echo("=" * 52)
-            click.echo(f"  Fractal Node : {env.meta_config.name}")
-            click.echo(f"  Transport    : {transport or 'peer multicast'}")
-            click.echo(f"  Session Scope: {session_scope}")
-            click.echo(f"  Started at   : {datetime.now().strftime('%H:%M:%S')}")
-            click.echo("=" * 52)
-            click.echo("  Providing moss runtime to remote hub...")
-            click.echo("")
-
-            try:
-                await moss_runtime.wait_close()
-            except asyncio.CancelledError:
-                pass
-
-    async def _main():
-        async with moss_runtime:
-            _ = moss_runtime.matrix.create_task(run_fractal(moss_runtime.matrix))
-            try:
-                await moss_runtime.wait_close()
-            except asyncio.CancelledError:
-                moss_runtime.close()
+    click.echo("")
+    click.echo("=" * 52)
+    click.echo(f"  Fractal Node Provider")
+    click.echo(f"  Mode         : {mode}")
+    click.echo(f"  Transport    : {transport or 'peer multicast'}")
+    click.echo(f"  Session Scope: {session_scope}")
+    click.echo(f"  Started at   : {datetime.now().strftime('%H:%M:%S')}")
+    click.echo("=" * 52)
+    click.echo("")
 
     try:
-        asyncio.run(_main())
+        # 使用 MossHost 提供的 provide_moss_as_fractal 方法
+        # 它会自动从 IoC 容器获取 FractalNodeProvider
+        asyncio.run(host.provide_moss_as_fractal(provider=None))
     except KeyboardInterrupt:
         click.echo("\nStopped.")
-        moss_runtime.close()
+    except NotImplementedError as e:
+        click.echo(f"\nError: {e}")
+        click.echo("请确保 workspace 中已注册 ZenohSessionFractalNodeProvider。")

--- a/src/ghoshell_moss/core/blueprint/host.py
+++ b/src/ghoshell_moss/core/blueprint/host.py
@@ -202,6 +202,7 @@ class FractalHub(ABC):
     MossHost 实现基于环境发现构建 HostRuntime 的能力
     """
 
+    @property
     def name(self) -> str:
         """
         hub 自身的命名, 也是 as_channel 返回 channel 的默认前缀.

--- a/src/ghoshell_moss/core/ctml/shell/ctml_shell.py
+++ b/src/ghoshell_moss/core/ctml/shell/ctml_shell.py
@@ -357,6 +357,7 @@ class CTMLShell(MOSShell[PrimeChannel]):
         if not self.is_running():
             return
         self._last_channel_metas = None
+        self._moss_static_cache = None
         refresh_meta_future = self._main_runtime.refresh_metas()
         if timeout is not None:
             sleep_task = asyncio.create_task(asyncio.sleep(timeout))
@@ -394,6 +395,7 @@ class CTMLShell(MOSShell[PrimeChannel]):
             if channel_meta.available or not available_only:
                 result[channel_path] = channel_meta
         self._last_channel_metas = result
+        self._last_channel_metas_refreshed_at = time.time()
         return result
 
     def push_task(self, *tasks: CommandTask) -> None:

--- a/src/ghoshell_moss/host/fractal/zenoh_fractal.py
+++ b/src/ghoshell_moss/host/fractal/zenoh_fractal.py
@@ -24,7 +24,10 @@ import time
 depend_zenoh()
 import zenoh
 
-__all__ = ['ZenohSessionFractalHub', 'FractalHubChannelState', 'ZenohFractalHubProvider', 'ZenohSessionFractalNodeProvider']
+__all__ = [
+    'ZenohSessionFractalHub', 'FractalHubChannelState', 'ZenohFractalHubProvider',
+    'ZenohSessionFractalNodeProvider', 'ZenohFractalNodeProviderProvider',
+]
 
 
 class ZenohSessionFractalHub(FractalHub):
@@ -447,6 +450,7 @@ class ZenohFractalHubProvider(Provider[FractalHub]):
             logger=logger,
         )
 
+
 class ZenohSessionFractalNodeProvider(FractalNodeProvider):
     """
     将本地 channel 通过 zenoh 暴露到远程 FractalHub。
@@ -598,3 +602,39 @@ class ZenohSessionFractalNodeProvider(FractalNodeProvider):
                 await channel_provider.arun_until_closed(moss.shell.main_channel)
 
             await moss.matrix.create_task(provide_moss_channels())
+
+
+class ZenohFractalNodeProviderProvider(Provider[FractalNodeProvider]):
+    """
+    IoC Provider for FractalNodeProvider。
+    读取 workspace 中的 zenoh_config_fractal.json5 创建 ZenohSessionFractalNodeProvider。
+    """
+
+    def __init__(self, conf_file: str = "zenoh_config_fractal.json5"):
+        self._conf_file = conf_file
+
+    def singleton(self) -> bool:
+        return True
+
+    def contract(self) -> type:
+        return FractalNodeProvider
+
+    def aliases(self) -> Iterable[Type]:
+        yield ZenohSessionFractalNodeProvider
+
+    def factory(self, con: IoCContainer) -> ZenohSessionFractalNodeProvider:
+        workspace = con.force_fetch(Workspace)
+        logger = con.get(LoggerItf)
+
+        config_path = workspace.configs().abspath() / self._conf_file
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"Fractal node zenoh config not found: {config_path}"
+            )
+        env = con.force_fetch(Environment)
+        meta = env.meta_config
+        return ZenohSessionFractalNodeProvider(
+            hub_name=meta.name,
+            zenoh_conf_file=config_path,
+            logger=logger,
+        )

--- a/src/ghoshell_moss/host/moss_runtime.py
+++ b/src/ghoshell_moss/host/moss_runtime.py
@@ -101,6 +101,11 @@ class MossRuntimeImpl(MossRuntime):
     def moss_static_messages(self) -> str:
         return self._ctml_shell.static_messages()
 
+    async def moss_refresh_metas(self, timeout: float = 2.0) -> None:
+        """刷新 channel metas 缓存, 使 static/dynamic 消息反映最新状态."""
+        self._check_shell_running()
+        await self._ctml_shell.refresh_metas(timeout)
+
     async def moss_observe(
             self,
             timeout: float | None = None,

--- a/src/ghoshell_moss/host/repl/fractal_serve_state.py
+++ b/src/ghoshell_moss/host/repl/fractal_serve_state.py
@@ -28,7 +28,7 @@ class _FractalOps:
         if hub is None:
             return "No FractalHub configured in this environment.\nUse `moss manifests contracts` to check if FractalHub is registered."
         if not hub.is_running():
-            return f"FractalHub '{hub.name()}' is not running.\nUse `/fractal.start()` to start listening."
+            return f"FractalHub '{hub.name}' is not running.\nUse `/fractal.start()` to start listening."
         return hub.status()
 
     async def start(self) -> str:
@@ -36,9 +36,9 @@ class _FractalOps:
         if hub is None:
             return "No FractalHub configured. Check workspace configs/zenoh_config_fractal_hub.json5."
         if hub.is_running():
-            return f"FractalHub '{hub.name()}' already running."
+            return f"FractalHub '{hub.name}' already running."
         await hub.__aenter__()
-        return f"FractalHub '{hub.name()}' started."
+        return f"FractalHub '{hub.name}' started."
 
     async def stop(self) -> str:
         hub = self._state.hub
@@ -96,7 +96,7 @@ class FractalServeState(REPLState):
             else:
                 self.console.info(
                     "Fractal Serve — 分形 Hub 调试\n"
-                    f"Hub: {self._hub.name()}\n"
+                    f"Hub: {self._hub.name}\n"
                     f"Running: {self._hub.is_running()}\n"
                     "\n"
                     "Use `/fractal.start()` to begin listening.\n"

--- a/src/ghoshell_moss/host/repl/inspector_moss_runtime.py
+++ b/src/ghoshell_moss/host/repl/inspector_moss_runtime.py
@@ -21,8 +21,9 @@ class MOSSRuntimeInspector:
         messages = await self._moss_runtime.moss_dynamic_messages(refresh=refresh)
         self._output.output(OutputItem.new("Shell", *messages, log="moss dynamic instructions"))
 
-    def static(self) -> None:
+    async def static(self) -> None:
         """获取当前 MOSS 的静态上下文讯息. """
+        await self._moss_runtime.moss_refresh_metas()
         static = self._moss_runtime.moss_static_messages()
         self._output.syntax(static, 'xml')
 

--- a/src/ghoshell_moss/host/stubs/workspace/configs/zenoh_config_fractal.json5
+++ b/src/ghoshell_moss/host/stubs/workspace/configs/zenoh_config_fractal.json5
@@ -1,0 +1,10 @@
+{
+  // Zenoh Fractal Node 配置
+  // 用于子节点（如机器人开发板）连接到父节点 Hub。
+  // 使用随机端口，避免与 Matrix session 冲突。
+  mode: "peer",
+
+  listen: {
+    endpoints: ["tcp/0.0.0.0:0"]
+  },
+}

--- a/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/providers.py
+++ b/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/providers.py
@@ -9,7 +9,7 @@ from ghoshell_moss.host.providers.tts_service_provider import TTSServiceProvider
 from ghoshell_moss.host.providers.speech_service_provider import TTSSpeechServiceProvider
 from ghoshell_moss.host.providers.audio_player_provider import PyAudioPlayerProvider
 from ghoshell_moss.core.resources.memory_registry import InMemoryResourceRegistryProvider
-from ghoshell_moss.host.fractal.zenoh_fractal import ZenohFractalHubProvider
+from ghoshell_moss.host.fractal.zenoh_fractal import ZenohFractalHubProvider, ZenohFractalNodeProviderProvider
 
 moss_session_provider = WorkspaceSessionProvider()
 
@@ -32,3 +32,4 @@ speech_service_provider = TTSSpeechServiceProvider()
 resources_provider = InMemoryResourceRegistryProvider()
 
 fractal_hub_provider = ZenohFractalHubProvider()
+fractal_node_provider = ZenohFractalNodeProviderProvider()


### PR DESCRIPTION
  - moss-as-fractal 改用 host.provide_moss_as_fractal()，删除手动实现
  - 新增 ZenohFractalNodeProviderProvider IoC 类，注册到 stubs/workspace
  - 修复 /moss.static() 双层缓存失效：refresh_metas 清除 static cache， channel_metas 更新时间戳
  - inspector static() 改为 async，先刷新再输出
  - MossRuntime 新增 moss_refresh_metas() 公共方法
  - 新增 zenoh_config_fractal.json5 避免端口冲突 via claude code