### PR TITLE
Fix/state channel

### DIFF
--- a/.ai_partners/features/workstreams/2026/05/first-ghost-prototype/FEATURE.md
+++ b/.ai_partners/features/workstreams/2026/05/first-ghost-prototype/FEATURE.md
@@ -4,7 +4,7 @@ status: in_progress
 priority: P0
 created: 2026-05-14
 updated: 2026-05-22
-step: 12b_verified
+step: 13_verified
 depends: []
 milestone:
 description: >-
@@ -83,6 +83,7 @@ first-ghost-prototype/
 | 11c | on_challenge 旁路观察 | ChallengeObserver(Callable[[challenger, defender, verdict], None]) + Mindflow.on_challenge(), AbsMindflow._challenge_attention 内 fire | done |
 | 11b | Mindflow inspect + 自解释 | mindflow 探知接口、自解释接口 | pending |
 | 12 | 测试与 TUI | mock ghost + input signal 脚本测试 → TUI 全链路验证 | 12b done, 12c pending |
+| 13 | 反身性 channel 集成 | ghost.channel() 注册到 shell channel tree, stateful channel 状态切换命令可解析, 树裁剪验证 | done |
 
 ## 实现阶段关键决策（2026-05-16）— GhostRuntime 架构选型
 
@@ -395,6 +396,60 @@ session.add_input_signal("hello")
 ### 下一阶段
 
 Mindflow 默认 input signal 体系：感知侧的可观测性（signal 记录、on_impulse 旁路观察），补齐三循环全链路。之后 mock ghost + input signal → 脚本测试 → TUI 全链路验证。
+
+---
+
+## 实现阶段关键决策（2026-05-22）— Ghost 反身性 Channel 集成 + 两处 Bug 修复
+
+完成 Ghost.channel() 向 Shell channel tree 的注册，以及 StatefulChannel 状态切换命令的完整可解析链路。共修复两个 bug，新增三个验证脚本。
+
+### ghost.channel() wiring（4 行）
+
+在 `GhostRuntimeImpl._wire_mindflow()` 末尾，将 ghost.channel() 注册为 shell main_channel 的 virtual child：
+
+```python
+if ghost_channel := ghost.channel():
+    self._moss_runtime.shell.main_channel.add_virtual_channel(ghost_channel, "ghost")
+```
+
+之所以用 virtual child 而非 static child：tree 的静态子节点只在首次 refresh 时扫描（`refresh_time == 1`），而 ghost channel 在 mindflow wiring 阶段才就绪，晚于首次树扫描。virtual children 每次 refresh 都扫描。
+
+### Bug 1: _own_commands 存储了错误的 Command 对象
+
+```python
+# BEFORE (bug): switch_state 命令实际执行的是 stop_current_state
+commands[self._switch_state_command.name()] = self._stop_current_command
+# AFTER:
+commands[self._switch_state_command.name()] = self._switch_state_command
+```
+
+位置：`py_channel.py:613`。复制粘贴错误，key 名称和 value 对象不匹配。
+
+### Bug 2: _get_own_command 遗漏 runtime 级命令
+
+`get_own_command`（public）在 split 后检查了 `switch_state`/`stop_current_state`，但 `_get_own_command`（private）没有。`has_own_command` 调用的是 `_get_own_command`，导致 tree 递归查找 `ghost:switch_state` 时：
+
+1. 递归到 ghost runtime，`unique_name = "switch_state"`
+2. `has_own_command("switch_state")` → `_get_own_command("switch_state")` → 只查 `_main_state` 和 `_current_state` → 都找不到 → 返回 None
+3. `split_unique_name("switch_state")` → `relative_path = ""`（无前缀）→ 递归终止 → 返回 None
+
+**修复**：将 runtime 级命令检查从 `get_own_command` 移至 `_get_own_command`，使 `has_own_command` 和 `get_own_command` 共享同一查找逻辑。
+
+### 三个验证脚本
+
+| 脚本 | 验证内容 | 结果 |
+|------|---------|------|
+| `test_ghost_channel.py` | 基本 channel wiring: ghost channel 出现在 metas，命令可解析 | PASS |
+| `test_stateful_ghost_channel.py` | StatefulChannel 集成: 状态切换后命令列表正确变化，通过 `execute_command("ghost:switch_state", ...)` 切换（与模型通过 CTML 调用同一路径） | PASS |
+| `test_tree_pruning.py` | Channel 树裁剪: 不同状态可见不同子 channel（awake: voice+head+body / sleeping: voice only / bored: voice+head） | PASS |
+
+### 涉及文件
+
+- `src/ghoshell_moss/host/ghost_runtime.py` — ghost channel wiring（4 行新增）
+- `src/ghoshell_moss/core/py_channel.py` — Bug 1 修复（1 行）+ Bug 2 修复（get_own_command/_get_own_command 重构）
+- `scripts/ghost/test_ghost_channel.py` — 基本 channel wiring 验证
+- `scripts/ghost/test_stateful_ghost_channel.py` — StatefulChannel 状态切换验证
+- `scripts/ghost/test_tree_pruning.py` — Channel 树裁剪验证
 
 ---
 

--- a/scripts/ghost/test_ghost_channel.py
+++ b/scripts/ghost/test_ghost_channel.py
@@ -1,0 +1,82 @@
+"""Verify ghost.channel() is registered into shell's channel tree.
+
+Minimal end-to-end: MockGhost + simple channel -> GhostRuntime -> check metas.
+"""
+import asyncio
+from ghoshell_moss.host import Host
+from ghoshell_moss.ghosts.mock._meta import MockGhostMeta
+from ghoshell_moss.ghosts.mock._runtime import MockGhost
+from ghoshell_moss.core.blueprint.channel_builder import new_channel
+from ghoshell_moss.core.concepts.channel import Channel
+
+
+class ChannelGhostMeta(MockGhostMeta):
+    """MockGhostMeta that injects a channel into the ghost after factory."""
+
+    def __init__(self, channel: Channel, **kwargs):
+        super().__init__(**kwargs)
+        self._channel = channel
+
+    def factory(self, container):
+        ghost: MockGhost = super().factory(container)
+        ghost.set_channel(self._channel)
+        return ghost
+
+
+def build_test_channel() -> Channel:
+    ch = new_channel(name="test_ghost", description="Ghost reflexive control channel")
+
+    @ch.build.command(name="ping", doc="Respond pong.")
+    def ping() -> str:
+        return "pong"
+
+    @ch.build.command(name="echo", doc="Echo back the message.")
+    def echo(message: str) -> str:
+        return f"echo: {message}"
+
+    return ch
+
+
+async def main():
+    channel = build_test_channel()
+    meta = ChannelGhostMeta(
+        channel=channel,
+        name="channel_test",
+        description="Ghost with channel for testing.",
+    )
+
+    host = Host()
+    gr = host.run_ghost(meta, run_shell=True)
+
+    async with gr:
+        shell = gr.moss.shell
+        # NOTE: timeout=None waits for full refresh completion.
+        # timeout=0 would return immediately before virtual children are scanned.
+        await shell.refresh_metas(timeout=None)
+
+        metas = shell.runtime.metas()
+        print("=== channel tree metas ===\n")
+        for path, m in metas.items():
+            print(f"  '{path}'")
+            print(f"    description: {m.description}")
+            print(f"    commands   : {[c.name for c in m.commands]}")
+            print()
+
+        # command lookup
+        ping_cmd = shell.runtime.get_command("ghost:ping")
+        echo_cmd = shell.runtime.get_command("ghost:echo")
+        ghost_child = shell.runtime.get_child_channel("ghost")
+
+        print(f"get_child_channel('ghost')  -> {ghost_child.name() if ghost_child else 'None'}")
+        print(f"get_command('ghost:ping')   -> {ping_cmd.name() if ping_cmd else 'None'}")
+        print(f"get_command('ghost:echo')   -> {echo_cmd.name() if echo_cmd else 'None'}")
+
+        gr.close()
+
+    ghost_in_metas = any("ghost" in str(p) for p in metas)
+    commands_ok = ping_cmd is not None and echo_cmd is not None
+    print(f"\n{'PASS' if ghost_in_metas and commands_ok else 'FAIL'}: ghost in metas={ghost_in_metas}, commands={commands_ok}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/ghost/test_stateful_ghost_channel.py
+++ b/scripts/ghost/test_stateful_ghost_channel.py
@@ -1,0 +1,161 @@
+"""Verify stateful ghost channel: states with different commands per state.
+
+Scenario:
+  Ghost has 3 states: sleeping, awake, bored.
+  - sleeping: only wake_up
+  - awake: head_control, body_control, sleep
+  - bored: play, explore
+
+Validates state switching via the command system (same path the model uses via CTML).
+"""
+import asyncio
+from ghoshell_moss.host import Host
+from ghoshell_moss.ghosts.mock._meta import MockGhostMeta
+from ghoshell_moss.ghosts.mock._runtime import MockGhost
+from ghoshell_moss.core.blueprint.states_channel import new_prime_channel
+from ghoshell_moss.core.concepts.channel import Channel
+
+
+class StatefulGhostMeta(MockGhostMeta):
+    def __init__(self, channel: Channel, **kwargs):
+        super().__init__(**kwargs)
+        self._channel = channel
+
+    def factory(self, container):
+        ghost: MockGhost = super().factory(container)
+        ghost.set_channel(self._channel)
+        return ghost
+
+
+def build_ghost_channel() -> Channel:
+    ch = new_prime_channel(name="ghost", description="Ghost reflexive control surface")
+
+    sleeping = ch.new_state("sleeping", "Ghost is sleeping. Only wake_up is available.")
+
+    @sleeping.command(name="wake_up", doc="Wake up from sleep.")
+    def wake_up() -> str:
+        return "woken up"
+
+    @sleeping.idle
+    async def sleep_idle():
+        pass
+
+    awake = ch.new_state("awake", "Ghost is fully awake. Head and body control available.")
+
+    @awake.command(name="head_control", doc="Control head: yaw, pitch, roll.")
+    def head_control(yaw: float = 0.0, pitch: float = 0.0) -> str:
+        return f"head -> yaw={yaw}, pitch={pitch}"
+
+    @awake.command(name="body_control", doc="Control body: posture, gesture.")
+    def body_control(posture: str = "stand") -> str:
+        return f"body -> {posture}"
+
+    @awake.command(name="sleep", doc="Go to sleep.")
+    def sleep() -> str:
+        return "going to sleep"
+
+    @awake.idle
+    async def awake_idle():
+        pass
+
+    bored = ch.new_state("bored", "Ghost is bored. Entertainment commands available.")
+
+    @bored.command(name="play", doc="Play a game or activity.")
+    def play(game: str = "idle") -> str:
+        return f"playing {game}"
+
+    @bored.command(name="explore", doc="Explore the environment.")
+    def explore() -> str:
+        return "exploring"
+
+    @bored.idle
+    async def bored_idle():
+        pass
+
+    return ch
+
+
+def _ghost_meta(metas: dict):
+    for path, m in metas.items():
+        if path == "ghost" or path.endswith(".ghost"):
+            return m
+    return None
+
+
+async def switch_state(shell, state_name: str):
+    """Switch ghost state via command system — same path the model uses."""
+    await shell.runtime.execute_command("ghost:switch_state", kwargs={"name": state_name})
+
+
+async def main():
+    channel = build_ghost_channel()
+    meta = StatefulGhostMeta(
+        channel=channel, name="stateful_test", description="Stateful ghost test.",
+    )
+
+    host = Host()
+    gr = host.run_ghost(meta, run_shell=True)
+
+    async with gr:
+        shell = gr.moss.shell
+        await shell.refresh_metas(timeout=None)
+        runtime = shell.runtime
+
+        gm = _ghost_meta(runtime.metas())
+        assert gm is not None
+        assert len(gm.states) == 3
+        assert "switch_state" in {c.name for c in gm.commands}
+        print("=== 1. Ghost channel in metas, switch_state available ===")
+        print(f"  states: {list(gm.states.keys())}")
+        print(f"  commands: {[c.name for c in gm.commands]}\n")
+
+        # -- initial: no state-specific commands --
+        assert runtime.get_command("ghost:wake_up") is None
+        assert runtime.get_command("ghost:head_control") is None
+        print("=== 2. Initial: no state commands visible ===\n")
+
+        # -- awake --
+        await switch_state(shell, "awake")
+        await shell.refresh_metas(timeout=None)
+        gm = _ghost_meta(runtime.metas())
+        assert gm.current_state == "awake"
+        cmds = {c.name for c in gm.commands}
+        assert "head_control" in cmds
+        assert "body_control" in cmds
+        assert "sleep" in cmds
+        assert "wake_up" not in cmds
+        print("=== 3. Awake: head_control, body_control, sleep ===\n")
+
+        # -- sleeping --
+        await switch_state(shell, "sleeping")
+        await shell.refresh_metas(timeout=None)
+        gm = _ghost_meta(runtime.metas())
+        assert gm.current_state == "sleeping"
+        cmds = {c.name for c in gm.commands}
+        assert "wake_up" in cmds
+        assert "head_control" not in cmds
+        print("=== 4. Sleeping: only wake_up ===\n")
+
+        # -- bored --
+        await switch_state(shell, "bored")
+        await shell.refresh_metas(timeout=None)
+        gm = _ghost_meta(runtime.metas())
+        assert gm.current_state == "bored"
+        cmds = {c.name for c in gm.commands}
+        assert "play" in cmds
+        assert "explore" in cmds
+        print("=== 5. Bored: play + explore ===\n")
+
+        # idle hooks
+        states = channel.states()
+        for name in ("sleeping", "awake", "bored"):
+            assert len(states[name]._on_idle_funcs) == 1
+        print("=== 6. Idle hooks registered per state ===")
+
+        gr.close()
+
+    print("\n=== PASS: stateful ghost channel via command system ===")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/ghost/test_tree_pruning.py
+++ b/scripts/ghost/test_tree_pruning.py
@@ -1,0 +1,167 @@
+"""Verify stateful ghost channel with sub-channel TREE pruning.
+
+Tree structure:
+  ghost (StatefulChannel)
+  ├── voice (main_state — always visible)
+  │   └── speak
+  ├── head  (awake & bored — shared across two states)
+  │   └── look_at, nod
+  └── body  (awake only)
+      └── walk, stand
+
+State pruning:
+  - sleeping: voice + wake_up
+  - awake:    voice + head + body + all commands
+  - bored:    voice + head + play/explore
+
+State switching via command system — same path the model uses via CTML.
+"""
+import asyncio
+from ghoshell_moss.host import Host
+from ghoshell_moss.ghosts.mock._meta import MockGhostMeta
+from ghoshell_moss.ghosts.mock._runtime import MockGhost
+from ghoshell_moss.core.blueprint.states_channel import new_prime_channel
+from ghoshell_moss.core.blueprint.channel_builder import new_channel
+from ghoshell_moss.core.concepts.channel import Channel
+
+
+class StatefulGhostMeta(MockGhostMeta):
+    def __init__(self, channel: Channel, **kwargs):
+        super().__init__(**kwargs)
+        self._channel = channel
+
+    def factory(self, container):
+        ghost: MockGhost = super().factory(container)
+        ghost.set_channel(self._channel)
+        return ghost
+
+
+def build_voice_channel() -> Channel:
+    ch = new_channel("voice", "Voice output. Always available.")
+    ch.build.command(name="speak", doc="Say something.")(lambda text: f"said: {text}")
+    return ch
+
+
+def build_head_channel() -> Channel:
+    ch = new_channel("head", "Head control. Available when awake or bored.")
+    ch.build.command(name="look_at", doc="Look at target.")(lambda target: f"looking at {target}")
+    ch.build.command(name="nod", doc="Nod head.")(lambda: "nodded")
+    return ch
+
+
+def build_body_channel() -> Channel:
+    ch = new_channel("body", "Body control. Only available when awake.")
+    ch.build.command(name="walk", doc="Walk to target.")(lambda target: f"walking to {target}")
+    ch.build.command(name="stand", doc="Stand still.")(lambda: "standing")
+    return ch
+
+
+def build_ghost_channel(voice, head, body) -> Channel:
+    ch = new_prime_channel(name="ghost", description="Ghost reflexive control")
+    ch.main_state().import_channels(voice)
+
+    sleeping = ch.new_state("sleeping", "Ghost is sleeping.")
+
+    @sleeping.command(name="wake_up", doc="Wake up.")
+    def wake_up() -> str:
+        return "woken"
+
+    awake = ch.new_state("awake", "Ghost is fully awake.")
+    awake.import_channels(head, body)
+
+    @awake.command(name="sleep", doc="Go to sleep.")
+    def sleep() -> str:
+        return "sleeping"
+
+    bored = ch.new_state("bored", "Ghost is bored.")
+    bored.import_channels(head)
+
+    @bored.command(name="play", doc="Play something.")
+    def play(game: str = "idle") -> str:
+        return f"playing {game}"
+
+    @bored.command(name="explore", doc="Explore environment.")
+    def explore() -> str:
+        return "exploring"
+
+    return ch
+
+
+def _ghost_paths(metas: dict) -> set:
+    return {p for p in metas if p.startswith("ghost")}
+
+
+async def switch_state(shell, state_name: str):
+    """Switch ghost state via command system — same path the model uses."""
+    await shell.runtime.execute_command("ghost:switch_state", kwargs={"name": state_name})
+
+
+async def main():
+    voice = build_voice_channel()
+    head = build_head_channel()
+    body = build_body_channel()
+    channel = build_ghost_channel(voice, head, body)
+
+    meta = StatefulGhostMeta(channel=channel, name="tree_test", description="Tree pruning test.")
+    host = Host()
+    gr = host.run_ghost(meta, run_shell=True)
+
+    async with gr:
+        shell = gr.moss.shell
+        await shell.refresh_metas(timeout=None)
+        runtime = shell.runtime
+
+        # -- initial --
+        paths = _ghost_paths(runtime.metas())
+        assert "ghost" in paths
+        assert "ghost.voice" in paths
+        assert "ghost.head" not in paths
+        assert "ghost.body" not in paths
+        print(f"=== 1. Initial: only voice ===\n  {sorted(paths)}\n")
+
+        # -- awake --
+        await switch_state(shell, "awake")
+        await shell.refresh_metas(timeout=None)
+        paths = _ghost_paths(runtime.metas())
+        assert "ghost.voice" in paths
+        assert "ghost.head" in paths
+        assert "ghost.body" in paths
+        assert runtime.get_command("ghost:voice:speak") is not None
+        assert runtime.get_command("ghost:head:look_at") is not None
+        assert runtime.get_command("ghost:body:walk") is not None
+        print(f"=== 2. Awake: voice + head + body ===\n  {sorted(paths)}\n")
+
+        # -- sleeping --
+        await switch_state(shell, "sleeping")
+        await shell.refresh_metas(timeout=None)
+        paths = _ghost_paths(runtime.metas())
+        assert "ghost.voice" in paths
+        assert "ghost.head" not in paths
+        assert "ghost.body" not in paths
+        print(f"=== 3. Sleeping: head/body pruned ===\n  {sorted(paths)}\n")
+
+        # -- bored --
+        await switch_state(shell, "bored")
+        await shell.refresh_metas(timeout=None)
+        paths = _ghost_paths(runtime.metas())
+        assert "ghost.voice" in paths
+        assert "ghost.head" in paths
+        assert "ghost.body" not in paths
+        print(f"=== 4. Bored: voice + head (shared), body pruned ===\n  {sorted(paths)}\n")
+
+        # -- back to awake --
+        await switch_state(shell, "awake")
+        await shell.refresh_metas(timeout=None)
+        paths = _ghost_paths(runtime.metas())
+        assert "ghost.voice" in paths
+        assert "ghost.head" in paths
+        assert "ghost.body" in paths
+        print(f"=== 5. Awake: full tree restored ===\n  {sorted(paths)}\n")
+
+        gr.close()
+
+    print("=== PASS: tree pruning via command system ===")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/ghoshell_moss/core/py_channel.py
+++ b/src/ghoshell_moss/core/py_channel.py
@@ -610,7 +610,7 @@ class StateChannelRuntime(AbsChannelTreeRuntime[StatefulChannel]):
         if self._current_state is not None:
             commands[self._stop_current_command.name()] = self._stop_current_command
         if len(self._dynamic_states) > 0:
-            commands[self._switch_state_command.name()] = self._stop_current_command
+            commands[self._switch_state_command.name()] = self._switch_state_command
 
         if self._current_state is not None:
             for name, command in self._current_state.own_commands().items():
@@ -632,11 +632,6 @@ class StateChannelRuntime(AbsChannelTreeRuntime[StatefulChannel]):
             self,
             name: CommandUniqueName,
     ) -> Optional[Command]:
-        if self._current_state is not None and name == self._stop_current_command.name():
-            return self._stop_current_command
-        if len(self._dynamic_states) > 0 and name == self._switch_state_command.name():
-            return self._switch_state_command
-
         path, name = Command.split_unique_name(name)
         if path:
             return None
@@ -646,6 +641,10 @@ class StateChannelRuntime(AbsChannelTreeRuntime[StatefulChannel]):
             self,
             name: CommandUniqueName,
     ) -> Optional[Command]:
+        if self._current_state is not None and name == self._stop_current_command.name():
+            return self._stop_current_command
+        if len(self._dynamic_states) > 0 and name == self._switch_state_command.name():
+            return self._switch_state_command
         command = self._main_state.get_own_command(name)
         if command is not None:
             return command

--- a/src/ghoshell_moss/host/ghost_runtime.py
+++ b/src/ghoshell_moss/host/ghost_runtime.py
@@ -170,6 +170,10 @@ class GhostRuntimeImpl(GhostRuntime):
         # ignore any signals before started
         matrix.session.on_signal(_route_signal_to_mindflow)
 
+        # 6. Ghost 反身性 channel → Shell (virtual: 树已在 step2 完成首次静态扫描)
+        if ghost_channel := ghost.channel():
+            self._moss_runtime.shell.main_channel.add_virtual_channel(ghost_channel, "ghost")
+
     # ── 三循环 ────────────────────────────────────
 
     async def _main_loop(self) -> None:


### PR DESCRIPTION
…ing by deepseek-v4-pro

- Wire ghost.channel() as virtual child of shell main_channel in GhostRuntime._wire_mindflow()
- Fix _own_commands storing wrong Command for switch_state key (was _stop_current_command)
- Fix _get_own_command missing runtime-level command checks, causing has_own_command to dead-end
- Add 3 verification scripts: basic channel wiring, stateful channel switching, tree pruning

via claude code