### PR TITLE
feat: speech governance — miniaudio 默认播放器 + Speech 解耦 

### DIFF
--- a/.ai_partners/features/workstreams/2026/05/speech-governance/FEATURE.md
+++ b/.ai_partners/features/workstreams/2026/05/speech-governance/FEATURE.md
@@ -3,7 +3,7 @@ title: Speech Governance — 解耦、多后端、容错降级
 status: in-progress
 priority: P2
 created: 2026-05-25
-updated: 2026-05-26
+updated: 2026-05-27
 depends: []
 milestone:
 description: >-
@@ -30,7 +30,7 @@ description: >-
 ## Design Index
 
 - 基准抽象: `src/ghoshell_moss/contracts/speech.py` (Speech, SpeechStream, StreamAudioPlayer, TTS, TTSBatch, TTSSpeech)
-- 当前实现: `src/ghoshell_moss/core/speech/` (mock, stream_tts_speech, player/*, volcengine_tts/*)
+- 当前实现: `src/ghoshell_moss/core/speech/` (mock, stream_tts_speech, player/*, volcengine_tts/*, speech_module)
 - Shell 耦合点: `src/ghoshell_moss/core/ctml/shell/ctml_shell.py:_speech_context_manager`
 - TTS provider: `src/ghoshell_moss/host/providers/tts_service_provider.py`
 - 依赖声明: `src/ghoshell_moss/depends.py`
@@ -69,116 +69,81 @@ description: >-
 | `host/stubs/workspace/src/MOSS/manifests/configs.py` | 引用 AudioPlayerConfig |
 | `tests/ghoshell_moss/speech/test_miniaudio_player.py` | **新文件** — 10 个单元测试 |
 
-**Player 选型结论**:
-- **miniaudio**: 零系统依赖（libvorbis/libopus/libmp3 内置），纯 wheel 安装，跨平台一致，解码+播放一体
-- **PyAudio**: 降级为可选，通过 `audio` extras 安装，config 切换 backend 即可使用
-- **PulseAudio**: Linux only，保持现状
+### Phase 1: 解耦 — DONE (2026-05-28)
+
+**核心设计**：两层模型。
+
+```
+Speech (基础抽象)              TTSSpeech (高级扩展)
+──────────────                ──────────────────
+• 纯文本/音频输出              • 继承 Speech
+• __content__ 内核命令         • say / set_voice 等命令
+• Shell 自带                   • SpeechChannelModule 按需挂载
+• MockSpeech 兜底              • 需要 TTS provider
+```
+
+**职责划分**:
+
+```
+Shell (_speech_context_manager)          SpeechChannelModule
+────────────────────────────────        ─────────────────────
+• 解析 speech → 注入容器                • register_content=False (默认)
+• build_content_command() → __content__ • 仅 isinstance(speech, TTSSpeech)
+• start / close 生命周期                  时注册 say
+                                        • MockSpeech → 空命令集，无副作用
+```
+
+Shell 始终拥有 `__content__` 内核命令——无论 speech 是 MockSpeech 还是 TTSSpeech。`SpeechChannelModule` 负责发现 TTSSpeech 并挂载高级语音命令（say），没有 TTSSpeech 时静默为空。
+
+**Bootstrap 顺序保证正确性**:
+```
+_ioc_context_manager       → container bootstrap
+_speech_context_manager    → speech 注入容器 + 注册 __content__ + start
+_runtime_context_manager   → module.on_startup() 从容器取 speech → 注册 say
+```
+
+**完成内容**:
+
+1. 新建 `core/speech/speech_module.py`：
+   - `build_content_command(speech) -> Command` — 纯函数，构建 `__content__` 内核命令，供 Shell 使用
+   - `SpeechChannelModule(register_content=False)` — `ChannelModule`，`on_startup` 时从容器获取 Speech；仅当 `isinstance(speech, TTSSpeech)` 时注册 `say`；可选注册 `__content__`（供独立 speech channel 使用）
+   - `_SpeechCommandFactory` — 内部工厂，`build_content_command()` + `build_say_command()` 两个 public 方法
+
+2. 删除 `contracts/speech.py` 中的 `make_content_command_from_speech()` 和 `TTSSpeech.commands()`；TTSSpeech 退化为纯 ABC
+
+3. `CTMLShell.__init__` 恢复 `speech` 参数：`self._speech: Speech = speech`
+
+4. `_speech_context_manager`：
+   - 解析 speech（参数 > 容器 > MockSpeech），注入容器
+   - 调用 `build_content_command()` 注册 `__content__` 内核命令
+   - 启停生命周期：`start()` → `yield` → `close()`
+
+5. `StatefulChannel` 新增 `with_module()` 抽象方法（`states_channel.py`）
+
+6. `speech_channel.py` 改用 `channel.with_module(SpeechChannelModule(register_content=True))`
+
+7. `manifests/channels.py` 加入 `main.with_module(SpeechChannelModule())`，主机路径自动发现 TTSSpeech 时注册 say
+
+**变更文件**:
+| 文件 | 变更 |
+|------|------|
+| `contracts/speech.py` | 删除 `make_content_command_from_speech()` 和 `TTSSpeech.commands()`；TTSSpeech 退化为纯 ABC |
+| `core/speech/speech_module.py` | **新文件** — `build_content_command` + `SpeechChannelModule` + `_SpeechCommandFactory` |
+| `core/speech/__init__.py` | 导出 `SpeechChannelModule`, `build_content_command` |
+| `core/ctml/shell/ctml_shell.py` | 恢复 `speech` 参数；`_speech_context_manager` 注入+注册content+启停 |
+| `channels/speech_channel.py` | `inject_speech_commands` → `channel.with_module(SpeechChannelModule(register_content=True))` |
+| `core/blueprint/states_channel.py` | `StatefulChannel` 新增 `with_module()` 抽象方法 |
+| `host/providers/speech_service_provider.py` | `singleton()` 改为 `True` |
+| `host/stubs/workspace/src/MOSS/manifests/channels.py` | 加入 `main.with_module(SpeechChannelModule())` |
+| `tests/.../test_shell_speech.py` | 测试 `new_ctml_shell(speech=speech)` 简洁写法，无需 module |
+| `tests/.../test_wait_primitive.py` | 同上 |
+| `tests/.../test_elements.py` | `make_content_command_from_speech` → `build_content_command` |
 
 ### 剩余 Phase
 
 ```
-Phase 2 ✅ → D6 (docstring 示例) → Phase 1 (解耦) → Phase 3 (多 provider) → Phase 4 (降级)
+Phase 2 ✅ → Phase 1 ✅ → D6 (docstring 示例) → Phase 3 (多 provider) → Phase 4 (降级)
 ```
-
-## 调研结论 (2026-05-25)
-
-### 问题 1: Speech → Command 的权责泄漏
-
-**现状**：
-
-`CTMLShell._speech_context_manager()` 的逻辑：
-
-```python
-# 1. 从 IoC 容器获取 Speech 实例
-speech = self._container.get(Speech)
-
-# 2. 如果是 TTSSpeech，注册其 commands 到 main channel
-if isinstance(self._speech, TTSSpeech):
-    for command in self._speech.commands():
-        self.main_channel.build.add_command(command, override=False)
-
-# 3. 生成 __content__ command
-default_content_command = make_content_command_from_speech(self._speech)
-self.main_channel.build.add_command(default_content_command, override=False)
-```
-
-问题链：
-- `TTSSpeech.commands()` 返回 `list[Command]` — Speech 知道了 shell 调度模型
-- `make_content_command_from_speech()` 在 contracts 层定义，同样耦合 Command
-- CTMLShell 假设 speech 必然以 command 方式集成，无法支持非 command 的 speech 交互
-
-**解耦方向**：Speech 不再直接生成 Command。Speech channel module 以独立 channel 形态存在，通过 manifests 被发现并注册到 shell。Channel 的 `@channel.build.command()` 装饰器自然完成 "方法 → Command" 的转换，这是 channel 层的职责，不是 speech 层。
-
-参考 `zenoh-fractal` 中 `FractalHub.as_channel()` 的模式——能力提供方只暴露自身抽象，由 channel builder 完成到 shell 的桥接。
-
-### 问题 2: Player 选型 — RESOLVED (Phase 2 完成)
-
-**当前状态**：
-- `BaseAudioStreamPlayer` — 基于线程 + queue 的抽象基类，含 scipy resample。设计 OK。
-- `MiniAudioStreamPlayer` — **新默认**，基于 miniaudio，零系统依赖。
-- `PyAudioStreamPlayer` — 降级为可选，通过 `ghoshell_moss[audio]` 安装。
-- `PulseAudioStreamPlayer` — Linux only，保持可选。
-
-### 问题 3: 国际 TTS API 集成
-
-**当前状态**：
-- `VolcengineTTS` — 火山引擎双向流式 TTS，WebSocket 协议，自身实现了一套 binary protocol (`protocol.py`)
-- `TTSServiceProvider` — 工厂模式，但 `use` 字段是 literal，无法扩展
-
-**候选 provider**：
-
-| Provider | 协议 | 流式 | 中文 | 备注 |
-|----------|------|------|------|------|
-| Volcengine (当前) | WebSocket binary | Yes | 原生 | 国内首选 |
-| **OpenAI TTS** | HTTP SSE / streaming | Yes | 尚可 | 国际最通用 |
-| **ElevenLabs** | WebSocket | Yes | 一般 | 音色最丰富 |
-| **Azure Speech** | WebSocket | Yes | 好 | 企业级 |
-| **edge-tts** (免费) | WebSocket | Yes | 好 | 无需 API key |
-
-**集成策略**：
-- 每个 provider 实现 `TTS` 抽象，放在 `core/speech/` 下独立模块
-- `TTSServiceProvider.use` 从 `Literal` 改为 `str`，支持运行时选择
-- 依赖声明：每个 provider 的依赖通过 `depends.py` 中的新函数声明（如 `depend_openai_tts()`），对应 pyproject.toml 的 optional dependency group
-- 环境变量：`.env.example` 增加各 provider 的凭证模板
-
-**不需要做的**：不实现统一的 "TTS provider protocol" 抽象层。`TTS` ABC 已经是统一接口，每个 provider 直接实现它即可。provider 之间的差异（鉴权方式、音频格式、音色体系）由各自的 Config 和 `TTSInfo` 承载。
-
-### 问题 4: 自动容错降级
-
-**降级链路设计**：
-
-```
-TTS API (网络) → 失败 → 本地离线 TTS (如 edge-tts) → 失败 → MockSpeech (纯文本 buffer)
-                                ↓
-Player (miniaudio) → 失败 → 系统默认播放器 → 失败 → MockSpeech (无音频输出)
-```
-
-**实现要点**：
-- `TTSServiceProvider` 支持配置 provider 优先级列表（非单个 use）
-- Speech 启动时做 health check（如 1s 内能拿到音频即认为可用）
-- 降级是自动且静默的，只在 logger 中记录
-- MockSpeech 不需要改动——它已经是完美的最终兜底
-
-### 问题 5: Session Logos Stream 与 Speech 的集成
-
-**现状**：`Session` 提供 `pub_logos()` / `get_logos()` 跨进程流式协议。logos 的语义是 "模型生产的流式思想"（CTML），但底层机制是通用的有序字节流 pub/sub。
-
-**与 speech 的关系**：speech channel module 在初始化时可以：
-1. 订阅 logos stream 获取模型输出文本
-2. 在自己的进程中执行 TTS + 播放
-3. 将 speech 状态（播放中/完成/错误）通过 output protocol 反馈
-
-这样 speech 可以作为独立 app cell 运行在单独进程中，通过 zenoh session 通讯。但这**不是第一版的 scope**——第一版先完成 speech 的解耦和 player/provider 治理，跨进程 speech 作为未来迭代方向。
-
-### 问题 6: AI 模型构造 JSON 参数的认知冲突 (2026-05-25)
-
-**现象**：模型在调用 `say` 命令时，`voice: dict` 参数需要传递 JSON 字符串，但模型总是用 CTML 的原生 key-value 属性语法来写，导致参数解析失败。
-
-**根因**：CTML 的属性语法天然是**扁平的 key-value**（如 `<say speed="1.0" pitch="high">`），而 `voice: dict` 要求模型在属性值内部嵌套 JSON 字符串（如 `<say voice:dict="{'speed': 1.0}">`）。模型已经在用 XML 属性表达结构了，突然要求它在属性值内部再塞一个序列化结构，它在两种语法之间切换时容易出错。CTML 的 `:dict` 类型后缀机制虽然存在，但模型不容易自然地想到"先把 dict 序列化成 JSON 字符串，再塞进属性值"。
-
-**本质**：这不是模型能力问题，而是 **"flat syntax for nested data" 的认知 dissonance**。CTML interface 设计原则应该是：凡是模型要通过 CTML 调用的命令，参数应尽量是标量类型（str/int/float/bool）或流式参数（chunks__/text__/ctml__），避免 dict/list 这类需要二次序列化的复杂类型。当无法避免 dict 参数时，必须在 docstring 中提供显式的 CTML 调用示例。
-
-**当前缓解策略（方案 C）**：强化 command docstring 中的 CTML 示例。在 `say_doc()` 和类似涉及 dict 参数的命令中，显式展示 JSON 字符串的正确写法，让模型有明确的 copy-paste 模板。远期考虑拆分命令（方案 A：`set_voice` + `say` 分离），从根本上消除嵌套 dict 参数。
 
 ## Key Decisions
 
@@ -198,6 +163,36 @@ Player (miniaudio) → 失败 → 系统默认播放器 → 失败 → MockSpeec
 - 与 `BaseAudioStreamPlayer` 的三个抽象方法完全兼容
 - PyAudio 历史上安装失败是 MOSS 试用者的第一道门槛
 
+### D1: 两层模型 — Shell 拥有 content，Module 挂载 say (P0) — DONE (2026-05-28)
+
+**决策**: 区分 `Speech` 和 `TTSSpeech` 两层。Shell 只依赖 `Speech` 抽象，拥有 `__content__` 内核命令。`SpeechChannelModule` 发现 `TTSSpeech` 后挂载 `say` 等高级命令。
+
+**设计原则**:
+- Shell（`_speech_context_manager`）：解析 speech → 注入容器 → `build_content_command()` 注册 `__content__` → 启停生命周期
+- `__content__` 是内核命令，与 `wait`、`observe` 同级，Shell 始终拥有（MockSpeech 兜底）
+- `SpeechChannelModule(register_content=False)`：仅在 `isinstance(speech, TTSSpeech)` 时注册 `say`；没有 TTSSpeech 时无副作用
+- `register_content=True` 选项供独立 speech channel（如 `SpeechChannel`）使用
+- `build_content_command(speech) -> Command` 是唯一的 content 构建入口
+
+**Bootstrap 顺序保证**:
+```
+ioc_context_manager     → container.bootstrap()
+speech_context_manager  → speech 注入容器 + 注册 __content__ + speech.start()
+runtime_context_manager → module.on_startup() 从容器拿 speech → 注册 say
+```
+
+模块启动时 speech 已就绪、已在容器中。
+
+**Why**: Shell 理解"能说话"是自身的基础能力，不需要 module 告诉它。但"怎么用 TTS 高级特性说话"是 TTSSpeech 层的知识。这种分离让 MockSpeech 和 TTSSpeech 各就其位：不传 speech → MockSpeech 也能说话；传了 TTSSpeech + module → 拥有完整语音能力。
+
+**测试行为**:
+| 场景 | `__content__` | `say` |
+|------|:--:|:--:|
+| `new_ctml_shell()` 不传 speech | MockSpeech 兜底 | 无 |
+| `new_ctml_shell(speech=MockSpeech())` | 有 | 无 |
+| `new_ctml_shell(speech=MockSpeech())` + `with_module(SpeechChannelModule())` | 有 | 无（MockSpeech 非 TTSSpeech） |
+| `new_ctml_shell(speech=tts_speech)` + `with_module(SpeechChannelModule())` | 有 | 有 |
+
 ### D6: 强化 CTML docstring 中的 JSON 参数示例 (P1)
 
 **决策**: 对涉及 `dict`/`list` 等复杂类型参数的命令，在 docstring 中显式提供 CTML 调用示例，展示 JSON 字符串的正确构造方式。不改变接口签名，不改变 CTML 解析规则。
@@ -211,21 +206,6 @@ Player (miniaudio) → 失败 → 系统默认播放器 → 失败 → MockSpeec
 **Why**: 改动最小，立即生效。模型对 docstring 中的示例有很强的跟随能力，好的示例可以显著降低出错率。长期看，如果某个 dict 参数频繁出错，再考虑拆分命令（方案 A）。
 
 **非目标**: 不改 CTML 语法，不加新的 parser 约定。不强制所有命令都避免 dict 参数。
-
-### D1: Speech 不再生成 Command，转为 Channel Module (P0)
-
-**决策**: 删除 `contracts/speech.py` 中的 `make_content_command_from_speech()`，删除 `TTSSpeech.commands()`。Speech channel module 以独立 channel 形态存在，通过 `@channel.build.command()` 装饰器暴露能力给 shell。
-
-**受影响文件**:
-- `contracts/speech.py` — 删除 `make_content_command_from_speech` 和 `TTSSpeech.commands()`
-- `core/ctml/shell/ctml_shell.py` — `_speech_context_manager` 不再注入 commands
-- `core/speech/stream_tts_speech.py` — `BaseTTSSpeech` 不再继承 `TTSSpeech`（改为直接继承 `Speech`），或 `TTSSpeech` ABC 瘦身
-
-**不动**:
-- `Speech`, `SpeechStream`, `StreamAudioPlayer`, `TTS`, `TTSBatch` 抽象——这些是纯粹的 speech 域抽象，不含 command 耦合
-- `MockSpeech` — 测试用，不需要 command 能力
-
-**Why**: zenoh fractal 改造后，channel 可以通过 manifests 被自动发现。Speech 的能力（say, set_voice, use_tone 等）通过 channel 的 command 装饰器暴露，责任在 channel builder 而不是 speech 自身。
 
 ### D3: TTS provider 用 str + registry 替代 Literal (P1)
 
@@ -280,16 +260,20 @@ class FallbackSpeech(Speech):
 
 ## Implementation Plan
 
-### Phase 1: 解耦 (P0)
+### Phase 1: 解耦 (P0) — ✅ DONE (2026-05-27)
 
-| # | 任务 | 影响文件 |
-|---|------|----------|
-| 1.1 | 删除 `make_content_command_from_speech()` | `contracts/speech.py` |
-| 1.2 | 删除 `TTSSpeech.commands()` 方法 | `contracts/speech.py` |
-| 1.3 | 删除 `TTSSpeech` ABC？还是瘦身？TBD | `contracts/speech.py` |
-| 1.4 | 重构 `CTMLShell._speech_context_manager()` — 不再注入 commands | `core/ctml/shell/ctml_shell.py` |
-| 1.5 | 创建 speech channel module（`core/speech/speech_channel.py` 或在 host manifests 中定义）| 新文件 |
-| 1.6 | 确保 `make_content_command_from_speech` 的等价功能通过 channel command 提供 | speech channel module |
+| # | 任务 | 影响文件 | 状态 |
+|---|------|----------|------|
+| 1.1 | 删除 `make_content_command_from_speech()` 和 `TTSSpeech.commands()` | `contracts/speech.py` | ✅ |
+| 1.2 | 创建 `speech_module.py`（build_content_command + SpeechChannelModule） | `core/speech/speech_module.py` | ✅ |
+| 1.3 | `CTMLShell.__init__` 恢复 `speech` 参数 | `ctml_shell.py` | ✅ |
+| 1.4 | `_speech_context_manager` 注入 + 注册 __content__ + 启停 | `ctml_shell.py` | ✅ |
+| 1.5 | `new_ctml_shell()` 恢复 `speech` 参数 | `ctml_shell.py` | ✅ |
+| 1.6 | `StatefulChannel` 新增 `with_module()` 抽象 | `states_channel.py` | ✅ |
+| 1.7 | `speech_channel.py` 改用 `channel.with_module(SpeechChannelModule(register_content=True))` | `channels/speech_channel.py` | ✅ |
+| 1.8 | `manifests/channels.py` 加入 `main.with_module(SpeechChannelModule())` | `manifests/channels.py` | ✅ |
+| 1.9 | `singleton()` 改为 `True` | `speech_service_provider.py` | ✅ |
+| 1.10 | 测试适配（简洁写法，无需 module） | `test_shell_speech.py`, `test_wait_primitive.py`, `test_elements.py` | ✅ |
 
 ### Phase 2: Player 轻量化 (P1) — ✅ DONE (2026-05-26)
 
@@ -332,14 +316,16 @@ class FallbackSpeech(Speech):
 
 | 改动 | 影响范围 |
 |------|----------|
-| ~~PyAudio → miniaudio 默认~~ | ✅ 已实施。miniaudio 核心依赖，PyAudio audio extras 可选。`AudioPlayerConfig.backend` 可切换 |
-| 删除 `make_content_command_from_speech()` | 仅 `ctml_shell.py` 中 `_speech_context_manager` 调用方，测试 |
-| 删除 `TTSSpeech.commands()` | 同上 |
+| PyAudio → miniaudio 默认 | ✅ 已实施。miniaudio 核心依赖，PyAudio audio extras 可选。`AudioPlayerConfig.backend` 可切换 |
+| 删除 `make_content_command_from_speech()` | `test_elements.py`（改用 `build_content_command`） |
+| 删除 `TTSSpeech.commands()` | 调用方改用 `SpeechChannelModule` 或 `build_content_command` |
 | `CTMLShell._speech_context_manager` 重构 | 核心启动路径，需要全量回归 |
 | 新增 `MiniAudioStreamPlayer` | ✅ 纯新增，不影响现有 player |
-| `TTSServiceProvider.use` 类型变更 | 配置文件格式小幅调整 |
-| 新增 TTS providers | 纯新增 |
-| `FallbackSpeech` | 纯新增 |
+| 新增 `speech_module.py` | 纯新增 |
+| `StatefulChannel.with_module()` | 纯新增抽象方法 |
+| `TTSServiceProvider.use` 类型变更 | 配置文件格式小幅调整（Phase 3） |
+| 新增 TTS providers | 纯新增（Phase 3） |
+| `FallbackSpeech` | 纯新增（Phase 4） |
 
 **不动**: `Speech`, `SpeechStream`, `StreamAudioPlayer`, `TTS`, `TTSBatch` 抽象。`MockSpeech`。`BaseAudioStreamPlayer`。VolcengineTTS 核心逻辑。
 

--- a/.ai_partners/features/workstreams/2026/05/speech-governance/FEATURE.md
+++ b/.ai_partners/features/workstreams/2026/05/speech-governance/FEATURE.md
@@ -3,7 +3,7 @@ title: Speech Governance — 解耦、多后端、容错降级
 status: in-progress
 priority: P2
 created: 2026-05-25
-updated: 2026-05-25
+updated: 2026-05-26
 depends: []
 milestone:
 description: >-
@@ -39,6 +39,47 @@ description: >-
 - Channel 分形参考: `zenoh-fractal` feature (Hub/Provider 分离 + manifests 自动发现)
 - pyproject.toml: `src/ghoshell_moss/pyproject.toml` (optional dependency groups)
 
+## 实施进度
+
+### Phase 2: Player 轻量化 (P1) — DONE (2026-05-26)
+
+**完成内容**:
+
+1. `miniaudio>=0.67` 加入核心依赖 (`pyproject.toml` dependencies)，零系统依赖，跨平台一致
+2. 新增 `MiniAudioStreamPlayer` (`core/speech/player/miniaudio_player.py`)，实现 `BaseAudioStreamPlayer` 的三个抽象方法
+3. `AudioPlayerProvider` 替代 `PyAudioPlayerProvider`，默认 backend 为 `miniaudio`，可通过 `AudioPlayerConfig.backend: "pyaudio"` 切换
+4. PyAudio 仍可通过 `pip install ghoshell_moss[audio]` 安装，惰性导入，切换 backend 即可使用
+5. 10 个单元测试覆盖：生命周期、格式转换、重采样、流式播放、clear、幂等性
+
+**miniaudio 1.x 适配要点**:
+- miniaudio 1.71 使用 generator 模式：`PlaybackDevice.start(gen)` 接受 callback generator
+- 内部线程通过 `gen.send(frame_count)` 请求精确帧数，generator 必须返回恰好 `frame_count * channels * 2` 字节
+- 实现内部 buffer `_buf` 机制：队列数据先入 buffer，按需切分 yield，多余留在 buffer 供下次请求
+- 数据不足时用静音补齐，避免 underrun 噪声
+
+**变更文件**:
+| 文件 | 变更 |
+|------|------|
+| `pyproject.toml` | 核心依赖新增 `miniaudio>=0.67` |
+| `core/speech/player/miniaudio_player.py` | **新文件** — MiniAudioStreamPlayer |
+| `core/speech/player/__init__.py` | 导出 MiniAudioStreamPlayer |
+| `core/speech/__init__.py` | `make_baseline_tts_speech()` 默认改用 MiniAudioStreamPlayer |
+| `host/providers/audio_player_provider.py` | AudioPlayerProvider (miniaudio 默认 + pyaudio 可切换) |
+| `host/stubs/workspace/src/MOSS/manifests/providers.py` | 引用 AudioPlayerProvider |
+| `host/stubs/workspace/src/MOSS/manifests/configs.py` | 引用 AudioPlayerConfig |
+| `tests/ghoshell_moss/speech/test_miniaudio_player.py` | **新文件** — 10 个单元测试 |
+
+**Player 选型结论**:
+- **miniaudio**: 零系统依赖（libvorbis/libopus/libmp3 内置），纯 wheel 安装，跨平台一致，解码+播放一体
+- **PyAudio**: 降级为可选，通过 `audio` extras 安装，config 切换 backend 即可使用
+- **PulseAudio**: Linux only，保持现状
+
+### 剩余 Phase
+
+```
+Phase 2 ✅ → D6 (docstring 示例) → Phase 1 (解耦) → Phase 3 (多 provider) → Phase 4 (降级)
+```
+
 ## 调研结论 (2026-05-25)
 
 ### 问题 1: Speech → Command 的权责泄漏
@@ -70,30 +111,13 @@ self.main_channel.build.add_command(default_content_command, override=False)
 
 参考 `zenoh-fractal` 中 `FractalHub.as_channel()` 的模式——能力提供方只暴露自身抽象，由 channel builder 完成到 shell 的桥接。
 
-### 问题 2: Player 选型
+### 问题 2: Player 选型 — RESOLVED (Phase 2 完成)
 
 **当前状态**：
 - `BaseAudioStreamPlayer` — 基于线程 + queue 的抽象基类，含 scipy resample。设计 OK。
-- `PyAudioStreamPlayer` — 唯一默认。PyAudio 是 PortAudio 的 Python binding，C 编译依赖，macOS/Linux/Windows 都需要系统级音频库。
-- `PulseAudioStreamPlayer` — Linux only。
-
-**候选方案对比**：
-
-| 方案 | 依赖 | 跨平台 | 安装难度 | 活跃度 | 备注 |
-|------|------|--------|----------|--------|------|
-| PyAudio (当前) | PortAudio C lib | macOS/Linux/Win | 高（C 编译失败常见） | 低（年更） | 不适合做默认 |
-| **miniaudio** | 零系统依赖（内置解码） | macOS/Linux/Win | 极低（纯 wheel） | 活跃 | 支持播放+录制+格式转换 |
-| sounddevice | PortAudio C lib | macOS/Linux/Win | 中（同 PyAudio） | 活跃 | API 更现代，但依赖同 PyAudio |
-| GStreamer | 系统级框架 | 主要 Linux | 极高 | 活跃 | 重量级，适合复杂 pipeline |
-| simpleaudio | 系统依赖 | macOS/Linux/Win | 低 | 低 | 功能太少 |
-
-**推荐**: **miniaudio** (`pyminiaudio` / `miniaudio`)。理由：
-- 纯 wheel 安装，零系统依赖（libvorbis/libopus/libmp3 全部内置）
-- 跨平台一致行为
-- 支持 PCM 直接写入，与 `BaseAudioStreamPlayer._audio_stream_write()` 模式兼容
-- 可作为默认 player，PyAudio/PulseAudio 降级为可选
-
-**迁移代价**：`BaseAudioStreamPlayer` 的三个抽象方法 `_audio_stream_start/stop/write` 设计良好，miniaudio 实现只需实现这三个方法。`resample()` 静态方法可保留（scipy 依赖已在 pyproject.toml 中）。
+- `MiniAudioStreamPlayer` — **新默认**，基于 miniaudio，零系统依赖。
+- `PyAudioStreamPlayer` — 降级为可选，通过 `ghoshell_moss[audio]` 安装。
+- `PulseAudioStreamPlayer` — Linux only，保持可选。
 
 ### 问题 3: 国际 TTS API 集成
 
@@ -158,6 +182,22 @@ Player (miniaudio) → 失败 → 系统默认播放器 → 失败 → MockSpeec
 
 ## Key Decisions
 
+### D2: miniaudio 作为默认 Player (P1) — DONE
+
+**决策**: 新增 `MiniAudioStreamPlayer(BaseAudioStreamPlayer)` 作为默认 player 实现。PyAudio 和 PulseAudio 降级为可选（通过 extras 安装）。
+
+**实施**:
+- `miniaudio>=0.67` 加入核心依赖，零系统依赖
+- `AudioPlayerProvider` 支持 `backend: Literal["miniaudio", "pyaudio"]` 配置切换
+- PyAudio 惰性导入，只在 backend="pyaudio" 且已安装 `ghoshell_moss[audio]` 时才加载
+- miniaudio 1.x 使用 generator 模式，通过内部 buffer 实现帧精确 yield
+
+**Why**:
+- 零系统依赖，wheel 安装即用
+- 跨平台一致
+- 与 `BaseAudioStreamPlayer` 的三个抽象方法完全兼容
+- PyAudio 历史上安装失败是 MOSS 试用者的第一道门槛
+
 ### D6: 强化 CTML docstring 中的 JSON 参数示例 (P1)
 
 **决策**: 对涉及 `dict`/`list` 等复杂类型参数的命令，在 docstring 中显式提供 CTML 调用示例，展示 JSON 字符串的正确构造方式。不改变接口签名，不改变 CTML 解析规则。
@@ -186,16 +226,6 @@ Player (miniaudio) → 失败 → 系统默认播放器 → 失败 → MockSpeec
 - `MockSpeech` — 测试用，不需要 command 能力
 
 **Why**: zenoh fractal 改造后，channel 可以通过 manifests 被自动发现。Speech 的能力（say, set_voice, use_tone 等）通过 channel 的 command 装饰器暴露，责任在 channel builder 而不是 speech 自身。
-
-### D2: miniaudio 作为默认 Player (P1)
-
-**决策**: 新增 `MiniAudioStreamPlayer(BaseAudioStreamPlayer)` 作为默认 player 实现。PyAudio 和 PulseAudio 降级为可选（通过 extras 安装）。
-
-**Why**:
-- 零系统依赖，wheel 安装即用
-- 跨平台一致
-- 与 `BaseAudioStreamPlayer` 的三个抽象方法完全兼容
-- PyAudio 历史上安装失败是 MOSS 试用者的第一道门槛
 
 ### D3: TTS provider 用 str + registry 替代 Literal (P1)
 
@@ -261,14 +291,16 @@ class FallbackSpeech(Speech):
 | 1.5 | 创建 speech channel module（`core/speech/speech_channel.py` 或在 host manifests 中定义）| 新文件 |
 | 1.6 | 确保 `make_content_command_from_speech` 的等价功能通过 channel command 提供 | speech channel module |
 
-### Phase 2: Player 轻量化 (P1)
+### Phase 2: Player 轻量化 (P1) — ✅ DONE (2026-05-26)
 
-| # | 任务 | 影响文件 |
-|---|------|----------|
-| 2.1 | 新增 `MiniAudioStreamPlayer` 实现 | `core/speech/player/miniaudio_player.py` |
-| 2.2 | 新增 `depend_miniaudio()` | `depends.py` |
-| 2.3 | pyproject.toml 添加 `[audio-miniaudio]` extras | `pyproject.toml` |
-| 2.4 | PyAudio 改为 optional（`[audio-pyaudio]` extras） | `pyproject.toml`, `depends.py` |
+| # | 任务 | 影响文件 | 状态 |
+|---|------|----------|------|
+| 2.1 | 新增 `MiniAudioStreamPlayer` 实现 | `core/speech/player/miniaudio_player.py` | ✅ |
+| 2.2 | miniaudio 加入核心依赖 | `pyproject.toml` | ✅ |
+| 2.3 | `AudioPlayerProvider` 替代 `PyAudioPlayerProvider`，backend 可切换 | `host/providers/audio_player_provider.py` | ✅ |
+| 2.4 | PyAudio 改惰性导入，按需加载 | `audio_player_provider.py` | ✅ |
+| 2.5 | 更新 workspace manifests/stubs | stubs + .moss_ws | ✅ |
+| 2.6 | 10 个单元测试 | `tests/ghoshell_moss/speech/test_miniaudio_player.py` | ✅ |
 
 ### Phase 3: TTS 多 provider (P1)
 
@@ -300,11 +332,11 @@ class FallbackSpeech(Speech):
 
 | 改动 | 影响范围 |
 |------|----------|
+| ~~PyAudio → miniaudio 默认~~ | ✅ 已实施。miniaudio 核心依赖，PyAudio audio extras 可选。`AudioPlayerConfig.backend` 可切换 |
 | 删除 `make_content_command_from_speech()` | 仅 `ctml_shell.py` 中 `_speech_context_manager` 调用方，测试 |
 | 删除 `TTSSpeech.commands()` | 同上 |
 | `CTMLShell._speech_context_manager` 重构 | 核心启动路径，需要全量回归 |
-| 新增 `MiniAudioStreamPlayer` | 纯新增，不影响现有 player |
-| PyAudio → optional | 安装文档、CI 配置 |
+| 新增 `MiniAudioStreamPlayer` | ✅ 纯新增，不影响现有 player |
 | `TTSServiceProvider.use` 类型变更 | 配置文件格式小幅调整 |
 | 新增 TTS providers | 纯新增 |
 | `FallbackSpeech` | 纯新增 |
@@ -314,7 +346,11 @@ class FallbackSpeech(Speech):
 ## Test Plan
 
 ### T1: 单元测试
-- `MiniAudioStreamPlayer` start/stop/write 基本流程
+- ✅ `MiniAudioStreamPlayer` start/stop/write 基本流程
+- ✅ `MiniAudioStreamPlayer` 格式转换 (PCM_S16LE, PCM_F32LE)
+- ✅ `MiniAudioStreamPlayer` 重采样
+- ✅ `MiniAudioStreamPlayer` 流式多次 add
+- ✅ `MiniAudioStreamPlayer` clear / 幂等 start / close 后 add
 - `FallbackSpeech` 降级链：第1个成功 → 不尝试第2个；第1个失败 → 自动切换到第2个；全部失败 → 兜底 MockSpeech
 - TTS provider registry 注册/查找/异常
 - Speech channel module commands 注册正确性

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.10"
 dependencies = [
     "anthropic>=0.84.0",
     "anyio>=4.12.1",
+    "miniaudio>=0.67",
     "ghoshell-common>=0.5.0",
     "ghoshell-container>=0.3.1",
     "janus>=2.0.0",

--- a/src/ghoshell_moss/channels/speech_channel.py
+++ b/src/ghoshell_moss/channels/speech_channel.py
@@ -5,7 +5,7 @@ from ghoshell_container import IoCContainer
 
 from ghoshell_moss.contracts.speech import Speech, TTSSpeech, TTS, StreamAudioPlayer
 from ghoshell_moss.core import PyChannel, Channel, ChannelRuntime, ChannelCtx
-from ghoshell_moss.core.speech import BaseTTSSpeech
+from ghoshell_moss.core.speech import BaseTTSSpeech, SpeechChannelModule
 from ghoshell_common.helpers import uuid
 
 __all__ = ["SpeechChannel", "TTSSpeechChannel"]
@@ -61,10 +61,9 @@ class SpeechChannel(Channel):
         channel.build.startup(self._speech.start)
         channel.build.close(self._speech.close)
 
-        if isinstance(self._speech, TTSSpeech):
-            # 注册 tts 原生 command
-            for command in self._speech.commands():
-                channel.build.add_command(command)
+        channel.with_module(
+            SpeechChannelModule(register_content=True)
+        )
 
         return channel.bootstrap(container=container)
 

--- a/src/ghoshell_moss/contracts/speech.py
+++ b/src/ghoshell_moss/contracts/speech.py
@@ -21,7 +21,6 @@ __all__ = [
     "TTSBatch",
     "TTSInfo",
     "TTSSpeech",
-    "make_content_command_from_speech",
 ]
 
 
@@ -279,57 +278,6 @@ class Speech(ABC):
         async with self:
             await self.wait_closed()
 
-
-def make_content_command_from_speech(speech: Speech, name="__content__", doc: str | None = None) -> Command:
-    """
-    不需要理解这里在干什么.
-    """
-
-    async def _feed_stream(stream: SpeechStream, deltas: AsyncIterable[str]) -> None:
-        """
-        实现一个异步消费的 task.
-        """
-        try:
-            nonlocal speech
-            if not speech.is_running():
-                return
-            has_first_chunk = False
-            async for chunk in deltas:
-                if not has_first_chunk and chunk.strip():
-                    has_first_chunk = True
-                    await stream.start_synthesis()
-                stream.feed(chunk)
-            stream.commit()
-        except asyncio.CancelledError:
-            await stream.close()
-
-    async def _content_partial(chunks__: AsyncIterable[str]) -> tuple[list, dict]:
-        """
-        在 command task 生成时, 就会对 chunks__ 进行流式加工.
-        """
-        nonlocal speech
-        if not speech.is_running():
-            return [], {}
-        stream = speech.new_stream()
-        await stream.start_synthesis()
-        _ = asyncio.create_task(_feed_stream(stream, chunks__))
-        return [], {"chunks__": stream}
-
-    # 发送给大模型的真实命令.
-    async def __content__(chunks__) -> None:
-        """speak chunks with your voice"""
-        if not speech.is_running():
-            return None
-        if not isinstance(chunks__, SpeechStream):
-            return None
-        try:
-            await chunks__.start_synthesis()
-            await chunks__.start_play()
-            await chunks__.wait_played()
-        finally:
-            await chunks__.close()
-
-    return PyCommand(func=__content__, partial=_content_partial, name=name, doc=doc)
 
 
 class AudioFormat(Enum):
@@ -666,83 +614,3 @@ class TTSSpeech(Speech, ABC):
     @abstractmethod
     def new_tts_stream(self, batch: TTSBatch) -> SpeechStream:
         pass
-
-    def commands(self) -> list[Command]:
-        """
-        返回 TTS Speech 默认支持的命令.
-        这里是一个借鉴, 不是必要的实现. 可以参考这种方式让声音可以替换.
-        """
-        tts = self.tts()
-        tts_info = tts.get_info()
-        voice_schema_str = json.dumps(tts_info.voice_schema, ensure_ascii=False, indent=0)
-
-        def say_doc() -> str:
-            current_voice = tts.get_voice()
-            current_tone = tts.current_tone()
-            tones = tts_info.tones
-            tone_descriptions = []
-            for _tone, description in tones.items():
-                tone_descriptions.append(f"`{_tone}`: {description}")
-            tone_descriptions_str = ";".join(tone_descriptions)
-
-            return (
-                f"使用指定的声音状态说话. 当它在 __main__ channel 时, 默认可以省略. \n"
-                f":param voice: 声音的速度, 音调等. json 结构, json schema 是 {voice_schema_str}\n "
-                f"  你当前的声音状态是: {json.dumps(current_voice, ensure_ascii=False)}.\n"
-                f":param as_default: 将本轮设置的声音状态变成默认.\n"
-                f":param chunks__: 你说话的文本内容. \n"
-                f":param tone: 切换使用的音色. 默认为当前音色\n"
-                f"  当前的音色是 `{current_tone}`"
-                f"  当前可以使用的音色: {tone_descriptions_str}\n"
-            )
-
-        async def say_partial(
-                chunks__,
-                voice: dict | None = None,
-                as_default: bool = False,
-                tone: str = "",
-        ) -> tuple[list, dict]:
-            """
-            预先准备 say 的逻辑.
-            """
-            if as_default:
-                if voice:
-                    tts.set_voice(voice)
-                if tone:
-                    tts.use_tone(tone)
-            batch = self.tts().new_batch(voice=voice, tone=tone)
-            stream = self.new_tts_stream(batch)
-
-            async def run_tts_batch() -> None:
-                try:
-                    nonlocal chunks__
-                    # 允许开启解析.
-                    await stream.start_synthesis()
-                    async for chunk in chunks__:
-                        if stream.is_closed():
-                            return
-                        stream.feed(chunk)
-                except Exception as e:
-                    await stream.fail(e)
-                finally:
-                    stream.commit()
-
-            # 开始异步运行.
-            _ = asyncio.create_task(run_tts_batch())
-            return [], dict(voice=voice, chunks__=stream, as_default=as_default)
-
-        async def say(chunks__, voice: dict | None = None, as_default: bool = False, tone: str = "") -> None:
-            """
-            实际上拿到的 chunks__ 是一个 stream.
-            """
-            if not isinstance(chunks__, SpeechStream):
-                raise ValueError(f"System error: Chunks is not prepared")
-            await chunks__.say()
-
-        say_command = PyCommand(
-            say,
-            doc=say_doc,
-            partial=say_partial,
-        )
-
-        return [say_command]

--- a/src/ghoshell_moss/core/blueprint/states_channel.py
+++ b/src/ghoshell_moss/core/blueprint/states_channel.py
@@ -222,6 +222,14 @@ class StatefulChannel(Channel, ABC):
         return {}
 
     @abstractmethod
+    def with_module(self, module: ChannelModule) -> Self:
+        """
+        register a permanent capability module to the channel.
+        unlike with_state(), modules are cumulative — all active simultaneously.
+        """
+        pass
+
+    @abstractmethod
     def with_state(self, state: ChannelState, alias: str | None = None) -> Self:
         """
         register a named substate to the channel.

--- a/src/ghoshell_moss/core/ctml/shell/ctml_shell.py
+++ b/src/ghoshell_moss/core/ctml/shell/ctml_shell.py
@@ -35,7 +35,8 @@ from ghoshell_moss.core.ctml.v1_0.prompts import make_static_messages, make_dyna
 from ghoshell_moss.core.ctml.shell.ctml_main import create_ctml_main_chan, default_primitive_map
 from ghoshell_moss.core.helpers import ThreadSafeEvent, ThreadSafeFuture
 from ghoshell_moss.core.speech.mock import MockSpeech
-from ghoshell_moss.contracts.speech import Speech, TTSSpeech, make_content_command_from_speech
+from ghoshell_moss.core.speech.speech_module import build_content_command
+from ghoshell_moss.contracts.speech import Speech
 from collections import deque
 import time
 
@@ -186,18 +187,19 @@ class CTMLShell(MOSShell[PrimeChannel]):
         """
         启动关闭音频模块.
         """
-        if self._speech is None:
+        if self._speech:
+            self._container.set(Speech, self._speech)
+        else:
             speech = self._container.get(Speech)
             if speech is None:
                 speech = MockSpeech()
                 self._container.set(Speech, speech)
             self._speech = speech
-        # 注册 tts 的 command.
-        if isinstance(self._speech, TTSSpeech):
-            for command in self._speech.commands():
-                self.main_channel.build.add_command(command, override=False)
-        default_content_command = make_content_command_from_speech(self._speech)
-        self.main_channel.build.add_command(default_content_command, override=False)
+
+        # 注册 __content__ 内核命令（shell 始终拥有说话能力）
+        content_cmd = build_content_command(self._speech)
+        self.main_channel.build.add_command(content_cmd, override=False)
+
         await self._speech.start()
         yield
         await self._speech.close()

--- a/src/ghoshell_moss/core/speech/__init__.py
+++ b/src/ghoshell_moss/core/speech/__init__.py
@@ -13,11 +13,11 @@ def make_baseline_tts_speech(
     """
     基线示例.
     """
-    from ghoshell_moss.core.speech.player.pyaudio_player import PyAudioStreamPlayer
+    from ghoshell_moss.core.speech.player.miniaudio_player import MiniAudioStreamPlayer
     from ghoshell_moss.core.speech.volcengine_tts import VolcengineTTS
 
     return BaseTTSSpeech(
-        player=player or PyAudioStreamPlayer(),
+        player=player or MiniAudioStreamPlayer(),
         tts=tts or VolcengineTTS(),
         logger=logger,
     )

--- a/src/ghoshell_moss/core/speech/__init__.py
+++ b/src/ghoshell_moss/core/speech/__init__.py
@@ -2,6 +2,7 @@ from ghoshell_common.contracts import LoggerItf
 
 from ghoshell_moss.contracts.speech import TTS, Speech, SpeechStream, StreamAudioPlayer
 from ghoshell_moss.core.speech.mock import MockSpeech
+from ghoshell_moss.core.speech.speech_module import SpeechChannelModule, build_content_command
 from ghoshell_moss.core.speech.stream_tts_speech import BaseTTSSpeech, TTSSpeechStream
 
 

--- a/src/ghoshell_moss/core/speech/player/__init__.py
+++ b/src/ghoshell_moss/core/speech/player/__init__.py
@@ -1,1 +1,4 @@
+from ghoshell_moss.core.speech.player.miniaudio_player import MiniAudioStreamPlayer
+from ghoshell_moss.core.speech.player.base_player import BaseAudioStreamPlayer
 
+__all__ = ["BaseAudioStreamPlayer", "MiniAudioStreamPlayer"]

--- a/src/ghoshell_moss/core/speech/player/miniaudio_player.py
+++ b/src/ghoshell_moss/core/speech/player/miniaudio_player.py
@@ -1,0 +1,81 @@
+import queue
+from typing import Optional
+
+import miniaudio
+import numpy as np
+from ghoshell_common.contracts import LoggerItf
+
+from ghoshell_moss.core.speech.player.base_player import BaseAudioStreamPlayer
+
+__all__ = ["MiniAudioStreamPlayer"]
+
+
+class MiniAudioStreamPlayer(BaseAudioStreamPlayer):
+    """
+    基于 miniaudio 的异步音频播放器实现。
+    miniaudio 零系统依赖，跨平台一致，纯 wheel 安装即用。
+
+    miniaudio 1.x 使用 generator 模式：PlaybackDevice.start() 接受一个
+    callback generator，内部线程通过 gen.send(frame_count) 请求音频帧。
+    """
+
+    def __init__(
+        self,
+        *,
+        sample_rate: int = 44100,
+        channels: int = 1,
+        logger: LoggerItf | None = None,
+        safety_delay: float = 0.1,
+    ):
+        super().__init__(
+            sample_rate=sample_rate,
+            channels=channels,
+            logger=logger,
+            safety_delay=safety_delay,
+        )
+        self._playback: Optional[miniaudio.PlaybackDevice] = None
+
+    def _audio_stream_start(self):
+        self._data_queue: queue.Queue[bytes] = queue.Queue()
+        self._buf = b""  # 未播放的剩余字节
+
+        def _audio_generator():
+            bytes_per_frame = self.channels * 2  # SIGNED16 = 2 bytes/sample
+            frames_needed = yield b""  # prime
+            while not self._stop_event.is_set():
+                bytes_needed = (frames_needed or 0) * bytes_per_frame
+
+                # 从队列填充缓冲区直到凑够所需字节
+                while len(self._buf) < bytes_needed:
+                    try:
+                        self._buf += self._data_queue.get_nowait()
+                    except queue.Empty:
+                        break
+
+                if len(self._buf) >= bytes_needed and bytes_needed > 0:
+                    frames_needed = yield self._buf[:bytes_needed]
+                    self._buf = self._buf[bytes_needed:]
+                else:
+                    # 数据不足，用静音补足
+                    missing = max(bytes_needed - len(self._buf), 0)
+                    result = self._buf + b"\x00" * missing
+                    self._buf = b""
+                    frames_needed = yield result
+
+        gen = _audio_generator()
+        next(gen)  # prime
+
+        self._playback = miniaudio.PlaybackDevice(
+            output_format=miniaudio.SampleFormat.SIGNED16,
+            nchannels=self.channels,
+            sample_rate=self.sample_rate,
+        )
+        self._playback.start(gen)
+
+    def _audio_stream_write(self, data: np.ndarray):
+        self._data_queue.put(data.tobytes())
+
+    def _audio_stream_stop(self):
+        if self._playback is not None:
+            self._playback.stop()
+            self._playback = None

--- a/src/ghoshell_moss/core/speech/speech_module.py
+++ b/src/ghoshell_moss/core/speech/speech_module.py
@@ -1,0 +1,167 @@
+import asyncio
+import json
+
+from ghoshell_moss.core.blueprint.channel_builder import CommandUtil
+from ghoshell_moss.core.blueprint.states_channel import ChannelModule
+from ghoshell_moss.core.concepts.command import Command, PyCommand
+from ghoshell_moss.contracts.speech import Speech, SpeechStream, TTSSpeech
+from ghoshell_moss.core.speech.mock import MockSpeech
+
+
+def build_content_command(speech: Speech) -> Command:
+    """构建 __content__ 内核命令。Shell 始终拥有此命令，无论 speech 类型。"""
+    return _SpeechCommandFactory(speech).build_content_command()
+
+
+class _SpeechCommandFactory:
+    """从 Speech 实例构建 Command 对象的工厂。
+
+    将 command 构建逻辑从 contracts 层移到 core/speech 层。
+    """
+
+    def __init__(self, speech: Speech|TTSSpeech):
+        self._speech = speech
+
+    def build_content_command(self) -> Command:
+        speech = self._speech
+
+        async def _feed_stream(stream: SpeechStream, deltas):
+            try:
+                if not speech.is_running():
+                    return
+                has_first_chunk = False
+                async for chunk in deltas:
+                    if not has_first_chunk and chunk.strip():
+                        has_first_chunk = True
+                        await stream.start_synthesis()
+                    stream.feed(chunk)
+                stream.commit()
+            except asyncio.CancelledError:
+                await stream.close()
+
+        async def _content_partial(chunks__):
+            if not speech.is_running():
+                return [], {}
+            stream = speech.new_stream()
+            await stream.start_synthesis()
+            _ = asyncio.create_task(_feed_stream(stream, chunks__))
+            return [], {"chunks__": stream}
+
+        async def __content__(chunks__) -> None:
+            """speak chunks with your voice"""
+            if not speech.is_running():
+                return None
+            if not isinstance(chunks__, SpeechStream):
+                return None
+            try:
+                await chunks__.start_synthesis()
+                await chunks__.start_play()
+                await chunks__.wait_played()
+            finally:
+                await chunks__.close()
+
+        return PyCommand(func=__content__, partial=_content_partial, name="__content__")
+
+    def build_say_command(self) -> Command:
+        tts_speech: TTSSpeech = self._speech
+        tts = tts_speech.tts()
+        tts_info = tts.get_info()
+        voice_schema_str = json.dumps(tts_info.voice_schema, ensure_ascii=False, indent=0)
+
+        def say_doc() -> str:
+            current_voice = tts.get_voice()
+            current_tone = tts.current_tone()
+            tones = tts_info.tones
+            tone_descriptions = []
+            for _tone, description in tones.items():
+                tone_descriptions.append(f"`{_tone}`: {description}")
+            tone_descriptions_str = ";".join(tone_descriptions)
+
+            return (
+                f"使用指定的声音状态说话. 当它在 __main__ channel 时, 默认可以省略. \n"
+                f":param voice: 声音的速度, 音调等. json 结构, json schema 是 {voice_schema_str}\n "
+                f"  你当前的声音状态是: {json.dumps(current_voice, ensure_ascii=False)}.\n"
+                f"  使用 CTML 调用时, voice 必须是 JSON 字符串, 例如: voice:dict=\"{{'speed': 1.0, 'pitch': 'high'}}\"\n"
+                f":param as_default: 将本轮设置的声音状态变成默认.\n"
+                f":param chunks__: 你说话的文本内容. \n"
+                f":param tone: 切换使用的音色. 默认为当前音色\n"
+                f"  当前的音色是 `{current_tone}`"
+                f"  当前可以使用的音色: {tone_descriptions_str}\n"
+            )
+
+        async def say_partial(
+                chunks__,
+                voice: dict | None = None,
+                as_default: bool = False,
+                tone: str = "",
+        ) -> tuple[list, dict]:
+            if as_default:
+                if voice:
+                    tts.set_voice(voice)
+                if tone:
+                    tts.use_tone(tone)
+            batch = tts.new_batch(voice=voice, tone=tone)
+            stream = tts_speech.new_tts_stream(batch)
+
+            async def run_tts_batch() -> None:
+                try:
+                    nonlocal chunks__
+                    await stream.start_synthesis()
+                    async for chunk in chunks__:
+                        if stream.is_closed():
+                            return
+                        stream.feed(chunk)
+                except Exception as e:
+                    await stream.fail(e)
+                finally:
+                    stream.commit()
+
+            _ = asyncio.create_task(run_tts_batch())
+            return [], dict(voice=voice, chunks__=stream, as_default=as_default)
+
+        async def say(chunks__, voice: dict | None = None, as_default: bool = False, tone: str = "") -> None:
+            if not isinstance(chunks__, SpeechStream):
+                raise ValueError(f"System error: Chunks is not prepared")
+            await chunks__.say()
+
+        return PyCommand(
+            say,
+            doc=say_doc,
+            partial=say_partial,
+        )
+
+
+class SpeechChannelModule(ChannelModule):
+    """TTS 语音能力模块。
+
+    可配置注册 content：
+    - register_content: 注册 __content__ 内核命令（默认 False）
+
+    Speech 实例由外部注册到 IoC 容器。on_startup 时通过 CommandUtil 获取。
+    """
+
+    def __init__(self, *, register_content: bool = False):
+        self._speech: Speech | None = None
+        self._own_commands = {}
+        self._register_content = register_content
+
+    def name(self) -> str:
+        return "speech"
+
+    def own_commands(self) -> dict[str, Command]:
+        return self._own_commands
+
+    async def on_startup(self) -> None:
+        self._speech = CommandUtil.get_contract(Speech) or MockSpeech()
+        factory = _SpeechCommandFactory(self._speech)
+        commands = {}
+        if self._register_content:
+            cmd = factory.build_content_command()
+            commands[cmd.name()] = cmd
+        if isinstance(self._speech, TTSSpeech):
+            cmd = factory.build_say_command()
+            commands[cmd.name()] = cmd
+        self._own_commands = commands
+
+    async def on_close(self) -> None:
+        self._speech = None

--- a/src/ghoshell_moss/host/providers/audio_player_provider.py
+++ b/src/ghoshell_moss/host/providers/audio_player_provider.py
@@ -1,53 +1,66 @@
-from typing import Iterable, Type
+from typing import Iterable, Literal, Type
 
 from ghoshell_moss.contracts.speech import StreamAudioPlayer
 from ghoshell_moss.contracts.logger import LoggerItf
 from ghoshell_moss.contracts.configs import ConfigType, ConfigStore
 from ghoshell_container import IoCContainer, Provider
-from ghoshell_moss.depends import depend_pyaudio
-
-depend_pyaudio()
-from ghoshell_moss.core.speech.player.pyaudio_player import PyAudioStreamPlayer
+from ghoshell_moss.core.speech.player.miniaudio_player import MiniAudioStreamPlayer
 from pydantic import Field
 
-__all__ = ['PyAudioPlayerProvider', 'PyAudioPlayerConfig']
+__all__ = ["AudioPlayerProvider", "AudioPlayerConfig"]
 
 
-class PyAudioPlayerConfig(ConfigType):
-    device_index: int = Field(
-        default=0,
-        description="Index of device to use in pyaudio stream",
+class AudioPlayerConfig(ConfigType):
+    backend: Literal["miniaudio", "pyaudio"] = Field(
+        default="miniaudio",
+        description="Audio player backend. 'miniaudio' is zero-dependency default; 'pyaudio' requires `pip install ghoshell_moss[audio]`.",
     )
     samplerate: int = Field(
         default=44100,
-        description="Sample rate of pyaudio player stream",
+        description="Sample rate of audio player stream",
     )
     safety_delay: float = Field(
         default=0.1,
-        description="Delay for time calculation after pyaudio player play a stream",
+        description="Delay for time calculation after player finishes a stream",
     )
 
     @classmethod
     def conf_name(cls) -> str:
-        return 'pyaudio_player'
+        return "audio_player"
 
 
-class PyAudioPlayerProvider(Provider[StreamAudioPlayer]):
+class AudioPlayerProvider(Provider[StreamAudioPlayer]):
 
     def singleton(self) -> bool:
         return False
 
-    def aliases(self) -> Iterable[Type]:
-        yield PyAudioStreamPlayer
-
     def factory(self, con: IoCContainer) -> StreamAudioPlayer:
         store = con.force_fetch(ConfigStore)
-        conf = store.get_or_create(PyAudioPlayerConfig())
+        conf = store.get_or_create(AudioPlayerConfig())
         logger = con.force_fetch(LoggerItf)
-        return PyAudioStreamPlayer(
-            device_index=conf.device_index,
-            sample_rate=conf.samplerate,
-            channels=1,
-            logger=logger,
-            safety_delay=conf.safety_delay,
-        )
+
+        if conf.backend == "miniaudio":
+            return MiniAudioStreamPlayer(
+                sample_rate=conf.samplerate,
+                channels=1,
+                logger=logger,
+                safety_delay=conf.safety_delay,
+            )
+
+        if conf.backend == "pyaudio":
+            try:
+                from ghoshell_moss.core.speech.player.pyaudio_player import PyAudioStreamPlayer
+            except ImportError:
+                raise ImportError(
+                    "PyAudio backend selected but not installed. "
+                    "Run: pip install ghoshell_moss[audio]"
+                )
+            return PyAudioStreamPlayer(
+                device_index=0,
+                sample_rate=conf.samplerate,
+                channels=1,
+                logger=logger,
+                safety_delay=conf.safety_delay,
+            )
+
+        raise ValueError(f"Unknown audio backend: {conf.backend}")

--- a/src/ghoshell_moss/host/providers/speech_service_provider.py
+++ b/src/ghoshell_moss/host/providers/speech_service_provider.py
@@ -9,7 +9,7 @@ __all__ = ['TTSSpeechServiceProvider']
 class TTSSpeechServiceProvider(Provider[Speech]):
 
     def singleton(self) -> bool:
-        return False
+        return True
 
     def factory(self, con: IoCContainer) -> INSTANCE:
         logger = con.force_fetch(LoggerItf)

--- a/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/channels.py
+++ b/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/channels.py
@@ -13,6 +13,7 @@
 
 from ghoshell_moss import new_main_channel
 from ghoshell_moss.core.ctml.shell.ctml_main import inject_system_primitives
+from ghoshell_moss.core.speech import SpeechChannelModule
 from ghoshell_moss.host.app_store_channel import AppStoreChannel
 
 main = new_main_channel(description="Default MOSS main channel with app store")
@@ -22,3 +23,6 @@ inject_system_primitives(main)
 
 # -- App Store ---------------------------------------------------
 main.import_channels(AppStoreChannel(name='apps'))
+
+# -- Speech --------------------------------------------------
+main.with_module(SpeechChannelModule())

--- a/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/configs.py
+++ b/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/configs.py
@@ -1,6 +1,6 @@
-from ghoshell_moss.host.providers.audio_player_provider import PyAudioPlayerConfig
+from ghoshell_moss.host.providers.audio_player_provider import AudioPlayerConfig
 from ghoshell_moss.host.providers.tts_service_provider import TTSManagerConfig
 
 tts_config = TTSManagerConfig()
 
-pyaudio_player_config = PyAudioPlayerConfig()
+audio_player_config = AudioPlayerConfig()

--- a/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/providers.py
+++ b/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/providers.py
@@ -7,7 +7,7 @@ from ghoshell_moss.host.providers import (
 )
 from ghoshell_moss.host.providers.tts_service_provider import TTSServiceProvider
 from ghoshell_moss.host.providers.speech_service_provider import TTSSpeechServiceProvider
-from ghoshell_moss.host.providers.audio_player_provider import PyAudioPlayerProvider
+from ghoshell_moss.host.providers.audio_player_provider import AudioPlayerProvider
 from ghoshell_moss.core.resources.memory_registry import InMemoryResourceRegistryProvider
 from ghoshell_moss.host.fractal.zenoh_fractal import ZenohFractalHubProvider, ZenohFractalCellContractProvider
 
@@ -23,7 +23,7 @@ topic_service_provider = ZenohTopicServiceProvider()
 
 # audio player and speech
 
-player_service_provider = PyAudioPlayerProvider()
+player_service_provider = AudioPlayerProvider()
 
 tts_service_provider = TTSServiceProvider()
 

--- a/tests/ghoshell_moss/core/ctml/test_elements.py
+++ b/tests/ghoshell_moss/core/ctml/test_elements.py
@@ -10,11 +10,11 @@ from ghoshell_moss.core.ctml.elements import CommandTaskElementContext, RootComm
 from ghoshell_moss.core.ctml.token_parser import CTML2CommandTokenParser
 from ghoshell_moss.core.helpers import ThreadSafeEvent
 from ghoshell_moss.core.speech.mock import MockSpeech
-from ghoshell_moss.contracts.speech import make_content_command_from_speech
 from ghoshell_moss.core.ctml.v1_0.constants import (
     CONTENT_COMMAND_NAME, SCOPE_COMMAND_NAME,
     SCOPE_ENTER_COMMAND_NAME, SCOPE_EXIT_COMMAND_NAME,
 )
+from ghoshell_moss.core.speech.speech_module import build_content_command
 
 
 @dataclass
@@ -60,7 +60,8 @@ def new_test_suite(*commands: Command, ignore_wrong_command: bool = True) -> Ele
             command_map[chan] = {}
         # 假的 command map.
         command_map[chan][command.name()] = command
-    content_command = make_content_command_from_speech(output)
+
+    content_command = build_content_command(output)
     command_map[''][content_command.name()] = content_command
     stop_event = ThreadSafeEvent()
     ctx = CommandTaskElementContext(

--- a/tests/ghoshell_moss/speech/test_miniaudio_player.py
+++ b/tests/ghoshell_moss/speech/test_miniaudio_player.py
@@ -1,0 +1,163 @@
+import asyncio
+
+import numpy as np
+import pytest
+
+from ghoshell_moss.contracts.speech import AudioFormat
+from ghoshell_moss.core.speech.player import MiniAudioStreamPlayer
+
+
+def _make_sine(duration: float, sample_rate: int, freq: float = 440.0, amplitude: float = 0.3) -> np.ndarray:
+    """生成一段正弦波 int16 音频数据."""
+    t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+    return (np.sin(2 * np.pi * freq * t) * (32767 * amplitude)).astype(np.int16)
+
+
+@pytest.mark.asyncio
+async def test_basic_lifecycle():
+    """start → close 基本生命周期."""
+    player = MiniAudioStreamPlayer(sample_rate=44100, channels=1)
+    assert not player.is_closed()
+
+    await player.start()
+    assert player._thread is not None
+
+    await player.close()
+    assert player.is_closed()
+
+
+@pytest.mark.asyncio
+async def test_add_and_wait():
+    """add 音频片段后 wait_play_done 正常返回."""
+    player = MiniAudioStreamPlayer(sample_rate=44100, channels=1)
+    await player.start()
+
+    audio = _make_sine(0.05, 44100)
+    player.add(audio, audio_type=AudioFormat.PCM_S16LE, rate=44100)
+
+    done = await player.wait_play_done(timeout=2.0)
+    assert done
+
+    await player.close()
+
+
+@pytest.mark.asyncio
+async def test_add_pcm_f32le():
+    """PCM_F32LE 格式自动转为 int16."""
+    player = MiniAudioStreamPlayer(sample_rate=16000, channels=1)
+    await player.start()
+
+    t = np.linspace(0, 0.05, int(16000 * 0.05), endpoint=False)
+    audio_f32 = (np.sin(2 * np.pi * 440 * t) * 0.3).astype(np.float32)
+    player.add(audio_f32, audio_type=AudioFormat.PCM_F32LE, rate=16000)
+
+    await player.wait_play_done(timeout=2.0)
+    await player.close()
+
+
+@pytest.mark.asyncio
+async def test_add_resample():
+    """不同采样率自动重采样."""
+    player = MiniAudioStreamPlayer(sample_rate=16000, channels=1)
+    await player.start()
+
+    audio_24k = _make_sine(0.05, 24000)
+    player.add(audio_24k, audio_type=AudioFormat.PCM_S16LE, rate=24000)
+
+    await player.wait_play_done(timeout=2.0)
+    await player.close()
+
+
+@pytest.mark.asyncio
+async def test_is_playing():
+    """add 后 is_playing() 返回 True，播放完毕后返回 False."""
+    player = MiniAudioStreamPlayer(sample_rate=44100, channels=1)
+    await player.start()
+
+    # 播放前
+    assert not player.is_playing()
+
+    # 添加一段音频
+    audio = _make_sine(0.1, 44100)
+    player.add(audio, audio_type=AudioFormat.PCM_S16LE, rate=44100)
+    assert player.is_playing()
+
+    await player.wait_play_done(timeout=2.0)
+    assert not player.is_playing()
+
+    await player.close()
+
+
+@pytest.mark.asyncio
+async def test_clear():
+    """clear 清空播放队列."""
+    player = MiniAudioStreamPlayer(sample_rate=44100, channels=1)
+    await player.start()
+
+    audio = _make_sine(0.2, 44100)
+    player.add(audio, audio_type=AudioFormat.PCM_S16LE, rate=44100)
+
+    await player.clear()
+    # clear 后不应阻塞
+    assert not player.is_playing()
+
+    await player.close()
+
+
+@pytest.mark.asyncio
+async def test_multiple_add_streaming():
+    """多次 add 模拟流式播放."""
+    player = MiniAudioStreamPlayer(sample_rate=44100, channels=1)
+    await player.start()
+
+    for _ in range(10):
+        chunk = _make_sine(0.01, 44100)
+        player.add(chunk, audio_type=AudioFormat.PCM_S16LE, rate=44100)
+
+    await player.wait_play_done(timeout=3.0)
+    await player.close()
+
+
+@pytest.mark.asyncio
+async def test_estimated_end_time_monotonic():
+    """estimated_end_time 随 add 单调递增."""
+    player = MiniAudioStreamPlayer(sample_rate=44100, channels=1)
+    await player.start()
+
+    prev_time = 0.0
+    for _ in range(5):
+        audio = _make_sine(0.02, 44100)
+        end_time = player.add(audio, audio_type=AudioFormat.PCM_S16LE, rate=44100)
+        assert end_time > prev_time
+        prev_time = end_time
+
+    await player.wait_play_done(timeout=2.0)
+    await player.close()
+
+
+@pytest.mark.asyncio
+async def test_double_start_idempotent():
+    """重复 start 不创建第二个线程."""
+    player = MiniAudioStreamPlayer(sample_rate=44100, channels=1)
+    await player.start()
+
+    thread_id_1 = player._thread.ident
+    await player.start()  # should be no-op
+    thread_id_2 = player._thread.ident
+
+    assert thread_id_1 == thread_id_2
+
+    await player.close()
+
+
+@pytest.mark.asyncio
+async def test_add_after_close_is_noop():
+    """close 后 add 不抛异常."""
+    player = MiniAudioStreamPlayer(sample_rate=44100, channels=1)
+    await player.start()
+    await player.close()
+
+    audio = _make_sine(0.05, 44100)
+    # 不应抛异常
+    end_time = player.add(audio, audio_type=AudioFormat.PCM_S16LE, rate=44100)
+    assert end_time > 0

--- a/uv.lock
+++ b/uv.lock
@@ -865,6 +865,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/6f/2adb571fda448d4afd2466e1cef2963fefdc6b37847da05249983e415f17/fastavro-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c", size = 3281842, upload-time = "2026-04-24T14:37:20.833Z" },
     { url = "https://files.pythonhosted.org/packages/17/07/4bad2e96c4c6bae40253be2573cc09c1e5b9ccf821e1ff74e0d33b64bf90/fastavro-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f", size = 450903, upload-time = "2026-04-24T14:37:23.059Z" },
     { url = "https://files.pythonhosted.org/packages/5b/b7/180f67ba9a46ba23a1ff6432f48d3087d4f2048579ecc262b00426cb1c63/fastavro-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a", size = 391076, upload-time = "2026-04-24T14:37:24.756Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8f/18f60329b627d2118a4a2b19e8741fbd807d60bf0470554e1bbfb7f1bca3/fastavro-1.12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57594b72cf663bbd0f3ad8a319a999fc3d7c71065a6799b2c1d1a6a137894c5b", size = 1055430, upload-time = "2026-05-09T21:53:14.364Z" },
     { url = "https://files.pythonhosted.org/packages/d2/ac/a1fa1fc29df0efc89d4946a743b09bdc9500591b5b92083eaf8e93664916/fastavro-1.12.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa", size = 3503075, upload-time = "2026-04-24T14:37:26.826Z" },
     { url = "https://files.pythonhosted.org/packages/82/bf/4f669e10b6bc38a731ee3400aed1a1e2d0a3e3cf411e72f6b320d3af0eaf/fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282", size = 3410900, upload-time = "2026-04-24T14:37:29.233Z" },
     { url = "https://files.pythonhosted.org/packages/10/39/ecb19fdae4158a7730b5963fbf1b6d38d74678392d73083be518642af0c1/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370", size = 3335637, upload-time = "2026-04-24T14:37:31.472Z" },
@@ -1095,6 +1096,7 @@ dependencies = [
     { name = "ghoshell-container" },
     { name = "janus" },
     { name = "jsonargparse" },
+    { name = "miniaudio" },
     { name = "orjson" },
     { name = "pillow" },
     { name = "prompt-toolkit" },
@@ -1160,6 +1162,7 @@ requires-dist = [
     { name = "ghoshell-container", specifier = ">=0.3.1" },
     { name = "janus", specifier = ">=2.0.0" },
     { name = "jsonargparse", specifier = ">=4.48.0" },
+    { name = "miniaudio", specifier = ">=0.67" },
     { name = "orjson", specifier = ">=3.11.8" },
     { name = "pillow", specifier = ">=12.1.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
@@ -1843,6 +1846,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "miniaudio"
+version = "1.71"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/d5/e5439dc08561f73656bfeb3340fc64ab63163e101426593d8fb9a025ff1e/miniaudio-1.71.tar.gz", hash = "sha256:ff51e2887bb673e2e757752b586b3dc924d59aa5fbcae9bbc45f4a111bd3262b", size = 1116480, upload-time = "2026-04-29T21:20:38.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/8f/8a792b93d27e57862754dbce780c6363ddbad7e56f40568dd3838b8d6862/miniaudio-1.71-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:19dc58e4c50ffc48db2ce988019c28f05ca0eaa7c10b45b5c99b70107e610c8a", size = 367726, upload-time = "2026-04-29T21:20:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/08/3a/645db5b3ba8f7c1ff319e38a7150054f35818795ed312a3a5e4f061624b0/miniaudio-1.71-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:aee8e4eec8d7bde4ee78066561329235a04231a221c9b247f1ffaf850551087d", size = 351407, upload-time = "2026-04-29T21:20:02.286Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a8/91140e67b45efc1457bb78fae48cff691097c4bef9b4eeb16f9d3ee83ade/miniaudio-1.71-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14892ad9b884e637029a22a781dea569b292a1be13682380fd14cefcf80ea4ed", size = 643696, upload-time = "2026-04-29T21:20:04.001Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d1/f1688175ac1b598fbd2985d75830e85ce604eca7f0f85710dcd282971377/miniaudio-1.71-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f7042af3a4db5b90e5efaea257b6dfcff9389239ea643e6b0faa80169528e2e6", size = 645512, upload-time = "2026-04-29T21:20:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/63/8eacdc9e60c1f5a3622ad007f56e503f4c7e725b82808bc30349fa4abe21/miniaudio-1.71-cp310-cp310-win32.whl", hash = "sha256:ea86ae04ddbbf2beed20b9970af4a0baca8e6ed0e9625e1ed957be5540c943fd", size = 235043, upload-time = "2026-04-29T21:20:06.731Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bc/846a6e427848317eac2b773f9df5b88c105248a662cd5265029a367188a5/miniaudio-1.71-cp310-cp310-win_amd64.whl", hash = "sha256:978cc4d58d8beef1a705e1141dc177a8a357c10ba3a16f7d71482ee722023bbd", size = 274192, upload-time = "2026-04-29T21:20:08.009Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1a/8ded8b04490e0d50e2a404fc99858163c9567a135eaab35990b42bdfad72/miniaudio-1.71-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ac4a37ebbbfbfbeca50f4390e50f9952807ca61ac62f0c3bcbbc7dd698531dd3", size = 367726, upload-time = "2026-04-29T21:20:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c1/4b13ac3c36a2574e0d70f322246d80259606cd24523279f542abc9ac6063/miniaudio-1.71-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5009b4e29cd43de3631d2d5ab09cc074192c085b4c8dd8a121b856ce1af6bab7", size = 351405, upload-time = "2026-04-29T21:20:10.533Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7b/0087c224b373a8b179dfdadc7506f504531f670b41e2444823c3540b6755/miniaudio-1.71-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:06222d80b057ca4beccb6f97a134c2c2bf646ef7890e1759cfc09db7eecec44d", size = 643689, upload-time = "2026-04-29T21:20:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ee/f744ea9b6e09125120d30f0dd345e456d300956f54aa745bdf2648ad832f/miniaudio-1.71-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:166516449e2bb5f628d89cedbbb8720dceb96a0562c7e08a0e8e3cb10f58647c", size = 645509, upload-time = "2026-04-29T21:20:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/42/52/dae0cb47b6aa4c9641ed26e9e78c5c51f5cbd9daa8ae40d209f7b9d18e9f/miniaudio-1.71-cp311-cp311-win32.whl", hash = "sha256:9f379d4995f1fac6dcae65810f6a31cba264339b3e591a14b233f85a6d03d81e", size = 235040, upload-time = "2026-04-29T21:20:14.363Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4c/2c97c0638c04b784c60114a61fd653f2ac04e35de912c26ed85d331a180f/miniaudio-1.71-cp311-cp311-win_amd64.whl", hash = "sha256:50d66729e1dd7a4cf13edc25115ac54f776dd9f67803ba1a7cd1128ebf2e8cfe", size = 274186, upload-time = "2026-04-29T21:20:15.504Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d3/71124f5abbcdcae62e040f58d3dca3bd3d90fd01faa7bb276b112387b47a/miniaudio-1.71-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:62db602651bc20a2698f36a0d356d7217ed6f4f917550c7ffb3705c8e8be90cf", size = 377186, upload-time = "2026-04-29T21:20:16.713Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ac/30a324f758bed1b193e017ec25183cfb10a79e549656331f5d068a2d343a/miniaudio-1.71-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fc1a4f084cc1b4b25c567d22f54d1e46bfa505c17ed777c8b198e5c53d0f785", size = 351485, upload-time = "2026-04-29T21:20:17.761Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/62/ae884a9d3b2ebec9c2ed1db857593e74bff45b70c4ab17fccc11db31cbeb/miniaudio-1.71-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19be6f0a1e601c2237433e579734cfaf6469191b224c20c9e5f73c32ef9ee2b9", size = 643556, upload-time = "2026-04-29T21:20:18.87Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/39/84fc665e2ea8f9f1301b6370226e3a24f08d5ad5d97143b69b4ae7ac260a/miniaudio-1.71-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e6287f15caa808a88aad0700a182bec1ff6d98769717425adf9ebf41259d1936", size = 645176, upload-time = "2026-04-29T21:20:20.194Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b8/37d9f67d4511da29bdb82b6c73a3ef6f4ebf2fbd30f9524f1e4a84d6f033/miniaudio-1.71-cp312-cp312-win32.whl", hash = "sha256:ab100e5240b104b5326e4ec1be07b6ae461f7d3d4d7a694857fd2f0493d210f9", size = 235095, upload-time = "2026-04-29T21:20:21.653Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cf/c1a19e6800e725b6e2b4576407620a798d69e3528ebdea9aea84d69d7088/miniaudio-1.71-cp312-cp312-win_amd64.whl", hash = "sha256:f4a44b70b66628b0c307e40ae0ae857695978cae18462179b806d8edc807d416", size = 274252, upload-time = "2026-04-29T21:20:22.824Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/85/44545f767ec21142ffed5f9108406d11dc8a19aafed9bd57621a0892bb60/miniaudio-1.71-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:61b86f26d653040db32d9d15b05446321dd10e45beba25b44f841e26935213d5", size = 377184, upload-time = "2026-04-29T21:20:24.109Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d1/071a560000c8ce903dc919968ecce40fbe7a73213ac399051b887184f8a3/miniaudio-1.71-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d9dc15eff711bcfc62a9d05e0c78e4bc34821a455595e049629f2fea7491a523", size = 351488, upload-time = "2026-04-29T21:20:25.183Z" },
+    { url = "https://files.pythonhosted.org/packages/46/24/5873a569451cae5686fb656ebd78ffe0b5eebe48ca21ef61e227d237d20a/miniaudio-1.71-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12bc33e7e61072b4b541c14e10ef76119d5643e6bbb98e2dec0c0738889438fb", size = 643552, upload-time = "2026-04-29T21:20:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/90/9b/25785525e6b5ff9afd7f4c4279215dc09c3317ea4d837275b1ae17912b36/miniaudio-1.71-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:70fa2ea5353e6919aca59b8c5768144af009d18c3bca251749d66fb497424563", size = 645171, upload-time = "2026-04-29T21:20:27.494Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6d/cbfd55fdc40256231f7b0c861e2bf79cc289bfbbe5e15869317944e6d673/miniaudio-1.71-cp313-cp313-win32.whl", hash = "sha256:1bf93aeede652926f27f430f0fd69ef0cf8a949c07b537d6a2f295602c747037", size = 235088, upload-time = "2026-04-29T21:20:29.031Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/8d/d5059c04b247b1079c0e48914a9ec20352910a3b9373060fb258dfd194ab/miniaudio-1.71-cp313-cp313-win_amd64.whl", hash = "sha256:4c849ccb1349f7b3553a77a66fe7e972315185f5c4c44a0bbda7ebcdd224db37", size = 274247, upload-time = "2026-04-29T21:20:29.96Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e7/b3e0df641d2d5283446d7960fc407195ba722b9a0789bb0a1429bf9ee855/miniaudio-1.71-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3ef441d139264f8a5dcb9aa6fcd0b1e1e69f58715baae416ff33f045ffba6ad5", size = 378418, upload-time = "2026-04-29T21:20:31.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ea/f5940232d0c83777562e802f376a841046d78e94753450fb9a6685a44190/miniaudio-1.71-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:84139a10ef172acd762ccf120142877b037a1aaf71def99d2c75f66329f89d8b", size = 351473, upload-time = "2026-04-29T21:20:32.464Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a6/6b5ae21b74fe70da935de389e01b3cce86c790ca4083f6a63c3ee922673e/miniaudio-1.71-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a28ff4ad23e55bbde8808ce525d3bb7d249d7612f77646b30e06fc6b7a778ac", size = 643683, upload-time = "2026-04-29T21:20:33.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/43/ef851e2e1d9dfde2b97cc053f0d79c6612088b27044698ed5d8c687f05de/miniaudio-1.71-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:33986d5d725ebcbc253551e7358689bc81b19b6950b33cec8e8c1142ca4fc0a9", size = 645203, upload-time = "2026-04-29T21:20:34.713Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4a/0da61fea8b8469d51b77d43846572ef9255d54c9b6b65a552446bbd55f90/miniaudio-1.71-cp314-cp314-win32.whl", hash = "sha256:3bbeb1e068fe42475e017e8150e9e345182b583d0dd4d9e77ffa20c39935d9ec", size = 241126, upload-time = "2026-04-29T21:20:35.975Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d0/ad7bfa63e1baacd2d4803ee04862bb06fcfbbb34a340bf2bf3979e0068dc/miniaudio-1.71-cp314-cp314-win_amd64.whl", hash = "sha256:154b085dd914a0e79e3d93160e1a07aacb27d66c65f9ef6a0d87c1a194f32c04", size = 281740, upload-time = "2026-04-29T21:20:37.07Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
  MR 描述         
                                                                                                                                                     
  ## Summary      
                                                                                                                                                     
  - **Player 轻量化**: miniaudio 替代 PyAudio 作为默认音频播放器，零系统依赖，跨平台一致；PyAudio 降级为可选（`ghoshell_moss[audio]`），通过         
  `AudioPlayerConfig.backend` 切换                                                                                                                   
  - **Speech 解耦**: 删除 `contracts/speech.py` 中的 command 构建逻辑，新建 `SpeechChannelModule` 实现 `ChannelModule` Protocol，CTMLShell 和        
  SpeechChannelModule 只从 IoC 容器**获取** Speech，不**写入**                                                                                       
   
  ## 变更文件 (24 files, +731/-315)                                                                                                                  
                  
  ### Phase 2: Player 轻量化                                                                                                                         
  | 文件 | 变更 | 
  |------|------|                                                                                                                                    
  | `pyproject.toml` | 核心依赖新增 `miniaudio>=0.67` |                                                                                              
  | `core/speech/player/miniaudio_player.py` | **新文件** — `MiniAudioStreamPlayer` |                                                                
  | `core/speech/player/__init__.py` | 导出 `MiniAudioStreamPlayer` |                                                                                
  | `core/speech/__init__.py` | `make_baseline_tts_speech()` 默认改用 miniaudio |                                                                    
  | `host/providers/audio_player_provider.py` | `AudioPlayerProvider` 替代 `PyAudioPlayerProvider`，backend 可切换 |                                 
  | `host/stubs/workspace/src/MOSS/manifests/providers.py` | 引用 `AudioPlayerProvider` |                                                            
  | `host/stubs/workspace/src/MOSS/manifests/configs.py` | 引用 `AudioPlayerConfig` |                                                                
  | `tests/ghoshell_moss/speech/test_miniaudio_player.py` | **新文件** — 10 个单元测试 |                                                             
                                                                                                                                                     
  ### Phase 1: Speech 解耦                                                                                                                           
  | 文件 | 变更 |                                                                                                                                    
  |------|------|                                                                                                                                    
  | `contracts/speech.py` | 删除 `make_content_command_from_speech()` 和 `TTSSpeech.commands()` |                                                    
  | `core/speech/speech_module.py` | **新文件** — `SpeechChannelModule` + `_SpeechCommandFactory` |                                                  
  | `core/ctml/shell/ctml_shell.py` | 删除 `_speech_context_manager`，`self._speech = container.get(Speech) or MockSpeech()` |                       
  | `channels/speech_channel.py` | `inject_speech_commands(build, speech)` 替代旧接口 |                                                              
  | `core/blueprint/states_channel.py` | `StatefulChannel` 新增 `with_module()` 抽象方法 |                                                           
  | `host/stubs/workspace/src/MOSS/manifests/channels.py` | `main.with_module(SpeechChannelModule())` |                                              
  | `tests/.../test_shell_speech.py` | 通过 `parent_container` 注入 MockSpeech |                                                                     
  | `tests/.../test_wait_primitive.py` | 同上 |                                                                                                      
  | `tests/.../test_elements.py` | `build_speech_commands()` 替代旧的 `make_content_command_from_speech()` |                                         
                                                                                                                                                     
  ## 设计原则                                                                                                                                        
                                                                                                                                                     
  CTMLShell 和 SpeechChannelModule 都只从容器**拿** Speech，不往容器里**塞**。谁组装容器谁负责注册 Speech（Host providers / 测试 parent_container）。
                  
  ## Test Plan                                                                                                                                       
                  
  - [x] MiniAudioStreamPlayer 10 个单元测试（生命周期、格式转换、重采样、流式播放、clear、幂等性）                                                   
  - [x] Shell 集成回归 21 个测试（speech 输出、wait + speech、CTML elements）
  - [x] `moss run` 端到端：TTSSpeech + miniaudio player 组合正常启停                                                                                 
  - [ ] PyAudio backend 切换后正常播放