### PR TITLE
fix: cross-process image serialization lost in context_messages via proxy/provider        protocol

### DIFF
--- a/.ai_partners/features/workstreams/2026/05/echo-validation-and-fixes/FEATURE.md
+++ b/.ai_partners/features/workstreams/2026/05/echo-validation-and-fixes/FEATURE.md
@@ -3,10 +3,11 @@ title: Echo Ghost Validation & Fixes
 status: completed
 priority: P0
 created: 2026-05-23
-updated: 2026-05-25T23:30
+updated: 2026-05-27T17:00
 depends: [first-ghost-prototype]
 description: >-
   echo ghost human validation 中发现的 bug 修复。
+  包含跨进程 context_messages 图片序列化丢失的完整修复。
 ---
 
 # Echo Ghost Validation & Fixes
@@ -336,6 +337,83 @@ manifests_main = next(
 - `src/ghoshell_moss/message/contents/abcd.py` — TypedDict → typing_extensions
 - `src/ghoshell_moss_contrib/channels/slide_studio.py` — f-string 修复
 - `tests/` — 上述 4 个测试文件
+
+## 跨进程 context_messages 图片序列化丢失（2026-05-27, fixed）
+
+### 问题
+
+`.moss_ws/apps` 下的 channel 通过 `context_messages` 返回 PIL Image，经过 proxy/provider (zenoh) 协议跨进程传输后，proxy 侧收到的 context 中 image content 为空。
+
+### 根因
+
+四个 bug 叠加导致图片在序列化链路中消失：
+
+**Bug 1 — `Message.wrap_content()` 漏调 `.to_content()`**（`message.py:359-360`）
+
+`Base64Image.from_pil_image(item)` 返回的是 Pydantic BaseModel 实例，不是 `Content` TypedDict。直接放入 `contents` list 后，序列化时 `model_dump_json()` 无法正确识别 TypedDict 结构，`type` 和 `source` 键丢失。
+
+**Bug 2 — `Message.content_as_string()` 假设 `type` 键一定存在**（`message.py:487-493`）
+
+`content.get('type')` 未做防御，图片 Content 序列化失败后 `type` 缺失，导致 TUI 渲染时崩溃。
+
+**Bug 3 — `PyChannelBuilder._wrap_messages()` 丢弃累积的非 Message 对象**（`py_channel.py:131`）
+
+静态方法中 `result.append(msg)` 应为 `result.append(last)`。连续的非 Message raw items（如 PIL Image + str）被累积到 `last` Message 中，但遇到下一个 Message 时错误地 append 了当前 Message 而非累积的 `last`，导致前面累积的内容被丢弃。
+
+**Bug 4（主因）— `ChannelEventModel.to_channel_event()` 的 `exclude_unset=True`**（`protocol.py:62`）
+
+Pydantic 通过 `model_fields_set` 追踪字段是否被"显式设置"。`Message.with_content()` 内部使用 `self.contents.append()`（原地修改），不触发 `__setattr__`，Pydantic 认为 `contents` 字段 "unset"。`exclude_unset=True` 导致 `model_dump_json()` 静默丢弃 `contents`——这是跨进程传输后图片丢失的**根本原因**。
+
+单独测试 `Message.model_dump_json()` 能保留 contents 是因为没有 `exclude_unset`；但 `ChannelMetaUpdateEvent` → `ChannelMeta` → `Message` 的嵌套序列化经过 `to_channel_event()` 时 `exclude_unset=True` 被递归应用，contents 全部丢失。
+
+最小复现：
+```python
+from pydantic import BaseModel, Field
+class Demo(BaseModel):
+    items: list[str] = Field(default_factory=list)
+d = Demo()
+d.items.append('hello')
+d.model_dump_json(exclude_unset=True)  # → {} — items 丢失
+```
+
+### 方案
+
+| # | 文件 | 修复 |
+|---|------|------|
+| 1 | `message.py:360` | `Base64Image.from_pil_image(item)` → `.to_content()` |
+| 2 | `message.py:488-497` | `content['type']` → `content.get('type', 'unknown')`，图片类型展示 `media_type` 和 `base64_size` |
+| 3 | `py_channel.py:131` | `result.append(msg)` → `result.append(last)` |
+| 4 | `protocol.py:62` | 删除 `exclude_unset=True`；整个代码库中 `default_factory=list` + 原地 `.append()` 的模式太普遍，不应逐个修改 |
+
+### 单测覆盖
+
+新增测试文件 `tests/ghoshell_moss/core/ctml/shell/test_shell_image.py`（10 个用例）：
+
+| 测试 | 覆盖场景 |
+|------|---------|
+| `test_shell_image_baseline` | shell 命令直接返回 PIL Image |
+| `test_shell_image_return_bytes` | shell 命令返回图片 bytes |
+| `test_shell_image_in_sub_channel` | 子 channel 中的 image 命令 |
+| `test_shell_image_with_args` | 参数化图片生成 |
+| `test_context_messages_with_pil_image` | channel context_messages 返回 PIL Image（本地） |
+| `test_shell_context_messages_with_image` | shell 级 context_messages + refresh_metas |
+| `test_context_messages_with_image_and_text` | 混合 image + text 的 context_messages |
+| `test_context_messages_image_survives_serialization` | Message → JSON → dict → Message 往返 |
+| `test_image_content_survives_message_roundtrip` | wrap_content → Message → JSON → from_content 全链路 |
+| `test_context_messages_image_through_bridge` | **关键**：通过 thread bridge（同 `to_channel_event`/`from_channel_event` 序列化路径）的全链路集成测试 |
+
+### 为什么之前的单测没发现
+
+本地 PyChannel 测试不跨进程序列化，`ChannelMeta` 在进程内以 Python 对象传递，不经过 `to_channel_event()` → `model_dump_json(exclude_unset=True)` 路径。只有 app 部署通过 zenoh bridge 跨进程时才触发。
+
+Thread bridge（`create_thread_bridge`）虽然用 in-process Queue，但事件数据经过相同的 `model_dump_json()` / `json.loads()` 序列化/反序列化——因此 `test_context_messages_image_through_bridge` 能复现真实 zenoh 场景的 bug。
+
+### 位置
+
+- `src/ghoshell_moss/message/message.py` — wrap_content, content_as_string
+- `src/ghoshell_moss/core/py_channel.py` — _wrap_messages static method
+- `src/ghoshell_moss/core/duplex/protocol.py` — to_channel_event
+- `tests/ghoshell_moss/core/ctml/shell/test_shell_image.py` — 新增
 
 ## 复苏指引
 

--- a/src/ghoshell_moss/core/duplex/protocol.py
+++ b/src/ghoshell_moss/core/duplex/protocol.py
@@ -59,7 +59,6 @@ class ChannelEventModel(BaseModel, ABC):
     def to_channel_event(self) -> ChannelEvent:
         data = self.model_dump_json(
             exclude_none=True,
-            exclude_unset=True,
             exclude_defaults=True,
             exclude={"event_type", "connection_id", "event_id"},
             ensure_ascii=False,

--- a/src/ghoshell_moss/core/py_channel.py
+++ b/src/ghoshell_moss/core/py_channel.py
@@ -128,7 +128,7 @@ class PyChannelBuilder(ChannelStateBuilder, ChannelState):
         for msg in messages:
             if isinstance(msg, Message):
                 if last is not None:
-                    result.append(msg)
+                    result.append(last)
                 last = msg
             else:
                 if last is not None:

--- a/src/ghoshell_moss/message/message.py
+++ b/src/ghoshell_moss/message/message.py
@@ -357,7 +357,7 @@ class Message(BaseModel, WithAdditional):
         elif isinstance(item, ContentModel):
             _content = item.to_content()
         elif isinstance(item, Image.Image):
-            _content = Base64Image.from_pil_image(item)
+            _content = Base64Image.from_pil_image(item).to_content()
         elif isinstance(item, BaseModel):
             serialized = item.model_dump_json(indent=0, ensure_ascii=False, exclude_none=False)
             _content = Text.new_content(serialized)
@@ -488,9 +488,13 @@ class Message(BaseModel, WithAdditional):
         """以 string 为主的 content 显示. """
         if 'text' in content:
             return content['text'] or ''
-        else:
-            content_type = content['type']
-            return f'<content type="{content_type}"/>'
+        content_type = content.get('type', 'unknown')
+        source = content.get('source', {}) or {}
+        if content_type == 'image' and source:
+            media = source.get('media_type', '?')
+            data_len = len(source.get('data', '') or '')
+            return f'<content type="image" media_type="{media}" base64_size="{data_len}"/>'
+        return f'<content type="{content_type}"/>'
 
     def to_content_string(self) -> str:
         blocks = []

--- a/tests/ghoshell_moss/core/ctml/shell/test_shell_image.py
+++ b/tests/ghoshell_moss/core/ctml/shell/test_shell_image.py
@@ -1,0 +1,299 @@
+import io
+import pytest
+from PIL import Image as PILImage
+
+from ghoshell_moss.core import new_ctml_shell, new_channel, PyChannel
+from ghoshell_moss.message import Message, Text
+from ghoshell_moss.message.contents.images import Base64Image
+
+
+def _red_image(w=100, h=50) -> PILImage.Image:
+    return PILImage.new("RGB", (w, h), color="red")
+
+
+def _image_to_bytes(img: PILImage.Image, fmt="PNG") -> bytes:
+    buf = io.BytesIO()
+    img.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+# -- baseline: command returns PIL Image directly ------------------------
+
+
+@pytest.mark.asyncio
+async def test_shell_image_baseline():
+    """shell 执行命令, 直接拿到 PIL Image 对象."""
+    shell = new_ctml_shell()
+
+    @shell.main_channel.build.command()
+    async def get_image() -> PILImage.Image:
+        return _red_image(100, 50)
+
+    async with shell:
+        async with await shell.interpreter() as interpreter:
+            interpreter.feed("<get_image />")
+            interpreter.commit()
+            tasks = await interpreter.wait_tasks()
+            assert len(tasks) == 1
+            task = list(tasks.values())[0]
+            assert task.success()
+            result = task.result()
+            assert isinstance(result, PILImage.Image)
+            assert result.size == (100, 50)
+
+
+@pytest.mark.asyncio
+async def test_shell_image_return_bytes():
+    """shell 执行返回图片 bytes 的命令."""
+    shell = new_ctml_shell()
+
+    @shell.main_channel.build.command()
+    async def get_image_bytes() -> bytes:
+        img = _red_image(64, 64)
+        return _image_to_bytes(img)
+
+    async with shell:
+        async with await shell.interpreter() as interpreter:
+            interpreter.feed("<get_image_bytes />")
+            interpreter.commit()
+            tasks = await interpreter.wait_tasks()
+            assert len(tasks) == 1
+            task = list(tasks.values())[0]
+            assert task.success()
+            result = task.result()
+            assert isinstance(result, bytes)
+            # bytes 可以还原为 PIL Image
+            restored = PILImage.open(io.BytesIO(result))
+            assert restored.size == (64, 64)
+
+
+# -- channel with multiple image commands --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shell_image_in_sub_channel():
+    """子 channel 中的 image 命令, shell 可以从子 channel 路径调用."""
+    shell = new_ctml_shell()
+    img_chan = new_channel("img")
+
+    @img_chan.build.command()
+    async def capture() -> bytes:
+        img = _red_image(200, 100)
+        return _image_to_bytes(img, fmt="JPEG")
+
+    shell.main_channel.import_channels(img_chan)
+
+    async with shell:
+        async with await shell.interpreter() as interpreter:
+            interpreter.feed("<img:capture />")
+            interpreter.commit()
+            tasks = await interpreter.wait_tasks()
+            assert len(tasks) == 1
+            task = list(tasks.values())[0]
+            assert task.success()
+            result = task.result()
+            assert isinstance(result, bytes)
+            restored = PILImage.open(io.BytesIO(result))
+            assert restored.size == (200, 100)
+            assert restored.format == "JPEG"
+
+
+@pytest.mark.asyncio
+async def test_shell_image_with_args():
+    """image 命令接受参数动态生成图片."""
+    shell = new_ctml_shell()
+
+    @shell.main_channel.build.command()
+    async def create_image(width: int, height: int, color: str = "blue") -> bytes:
+        img = PILImage.new("RGB", (width, height), color=color)
+        return _image_to_bytes(img)
+
+    async with shell:
+        async with await shell.interpreter() as interpreter:
+            interpreter.feed('<create_image width="128" height="64" color="green" />')
+            interpreter.commit()
+            tasks = await interpreter.wait_tasks()
+            assert len(tasks) == 1
+            task = list(tasks.values())[0]
+            assert task.success()
+            result = task.result()
+            restored = PILImage.open(io.BytesIO(result))
+            assert restored.size == (128, 64)
+
+
+# -- context_messages returning image ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_messages_with_pil_image():
+    """channel 的 context_messages 返回 PIL Image, meta.context 中应有 Base64Image 消息."""
+    chan = PyChannel(name="vision")
+
+    @chan.build.context_messages
+    async def snapshot() -> list:
+        return [_red_image(320, 240)]
+
+    async with chan.bootstrap() as runtime:
+        meta = runtime.self_meta()
+        assert len(meta.context) == 1
+        msg = meta.context[0]
+        assert isinstance(msg, Message)
+        assert len(msg.contents) == 1
+        content = msg.contents[0]
+        # PIL Image → Base64Image.from_pil_image().to_content() → Content dict
+        assert Base64Image.match(content)
+        assert content["source"]["media_type"] == "image/png"
+        assert content["source"]["type"] == "base64"
+        assert len(content["source"]["data"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_shell_context_messages_with_image():
+    """shell 引入带 context_messages 的 channel, refresh 后 meta 中包含图片."""
+    shell = new_ctml_shell()
+    vision_chan = new_channel("vision")
+
+    @vision_chan.build.context_messages
+    async def snapshot() -> list:
+        return [_red_image(640, 480)]
+
+    shell.main_channel.import_channels(vision_chan)
+
+    async with shell:
+        await shell.refresh_metas()
+        metas = shell.channel_metas()
+        assert "vision" in metas
+        vision_meta = metas["vision"]
+        assert len(vision_meta.context) == 1
+        msg = vision_meta.context[0]
+        assert isinstance(msg, Message)
+        assert len(msg.contents) == 1
+        content = msg.contents[0]
+        assert Base64Image.match(content)
+        assert content["source"]["media_type"] == "image/png"
+        assert len(content["source"]["data"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_context_messages_with_image_and_text():
+    """context_messages 混合返回 PIL Image 和 str, 均被正确包装为 Message."""
+    chan = PyChannel(name="multi")
+
+    @chan.build.context_messages
+    async def mixed() -> list:
+        return [_red_image(100, 100), "camera snapshot at 30fps"]
+
+    async with chan.bootstrap() as runtime:
+        meta = runtime.self_meta()
+        # _wrap_messages 将连续的 raw item 合并到一个 Message 中
+        assert len(meta.context) == 1
+        msg = meta.context[0]
+        assert len(msg.contents) == 2
+        # 第一条 content 是 image
+        assert Base64Image.match(msg.contents[0])
+        assert msg.contents[0]["source"]["media_type"] == "image/png"
+        # 第二条 content 是 text
+        assert "camera snapshot" in Message.content_as_string(msg.contents[1])
+
+
+# -- serialization round-trip (跨进程传输场景) ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_messages_image_survives_serialization():
+    """模拟跨进程序列化/反序列化: Message → JSON → dict → Message, image content 不丢失."""
+    chan = PyChannel(name="vision")
+
+    @chan.build.context_messages
+    async def snapshot() -> list:
+        return [_red_image(320, 240)]
+
+    async with chan.bootstrap() as runtime:
+        meta = runtime.self_meta()
+        original_msg = meta.context[0]
+
+        # 序列化为 JSON 再还原（模拟跨进程传输）
+        json_str = original_msg.to_json()
+        raw = Message.model_validate_json(json_str)
+        assert isinstance(raw, Message)
+
+        # 反序列化后的 content 是 plain dict，但 from_content 应能还原
+        for content in raw.contents:
+            # Text.from_content 和 Base64Image.from_content 都需要 type 键
+            if text := Text.from_content(content):
+                continue
+            elif base64_image := Base64Image.from_content(content):
+                assert base64_image.source["media_type"] == "image/png"
+                assert len(base64_image.source["data"]) > 0
+                # data_url 可用于 pydantic-ai ImageUrl
+                assert base64_image.data_url.startswith("data:image/png;base64,")
+                break
+            else:
+                pytest.fail(f"content lost after deserialization: {content}")
+
+
+def test_image_content_survives_message_roundtrip():
+    """非 async: 直接验证 wrap_content → Message → JSON → 反序列化 → from_content 全链路."""
+    img = _red_image(64, 64)
+    msg = Message.new().with_content(img)
+
+    # 序列化往返
+    raw = Message.model_validate_json(msg.to_json())
+
+    assert len(raw.contents) == 1
+    content = raw.contents[0]
+    # 反序列化后是 Content dict，必须有 type 键才能被 from_content 匹配
+    assert "type" in content
+    assert content["type"] == "image"
+    # Base64Image.from_content 能正常工作
+    restored = Base64Image.from_content(content)
+    assert restored is not None
+    assert restored.data_url.startswith("data:image/png;base64,")
+
+
+# -- integration: full proxy/provider bridge with context_messages image --
+
+
+@pytest.mark.asyncio
+async def test_context_messages_image_through_bridge():
+    """context_messages 返回 PIL Image，通过 thread bridge 全链路序列化传输后 proxy 侧可拿到图片."""
+    from ghoshell_moss.core.duplex.thread_channel import create_thread_bridge
+
+    chan = PyChannel(name="vision")
+
+    @chan.build.context_messages
+    async def snapshot() -> list:
+        return [_red_image(320, 240)]
+
+    provider, proxy = create_thread_bridge("proxy")
+
+    async with provider.arun(chan):
+        async with proxy.bootstrap() as runtime:
+            await runtime.wait_connected()
+            assert runtime.is_running()
+
+            # 刷新 metas，触发 context_messages 通过 bridge 序列化传输
+            await runtime.refresh_metas()
+
+            metas = runtime.metas()
+            # provider 的 root channel 在 proxy 侧 key 为 ""，name 被 overwrite 为 proxy name
+            root_meta = metas.get("") or metas.get("vision")
+            assert root_meta is not None
+            assert len(root_meta.context) == 1
+
+            msg = root_meta.context[0]
+            assert isinstance(msg, Message)
+            assert len(msg.contents) == 1
+
+            content = msg.contents[0]
+            # 全链路序列化/反序列化后 Content dict 的 type 和 source 必须存活
+            assert content.get("type") == "image"
+            source = content.get("source") or {}
+            assert source.get("media_type") == "image/png"
+            assert source.get("type") == "base64"
+            assert len(source.get("data", "")) > 0
+
+            # from_content 还原为 Base64Image
+            restored = Base64Image.from_content(content)
+            assert restored is not None
+            assert restored.data_url.startswith("data:image/png;base64,")


### PR DESCRIPTION
## Summary                                                                               
                                                                                         
  - 修复 `context_messages` 返回图片时，经过 proxy/provider 协议跨进程传输后图片 content   
  消失的问题
  - 新增 10 个图片相关的单元测试，包括全链路 thread bridge 集成测试                        
                                                                                           
  ## Root Cause                                                                            
                                                                                           
  1. `message.py` `wrap_content()` — `Base64Image.from_pil_image()` 漏调                   
  `.to_content()`，Content dict 缺少 `type`/`source` 键                                  
  2. `message.py` `content_as_string()` — 假设 `type` 键一定存在，序列化失败后 TUI 崩溃    
  3. `py_channel.py` `_wrap_messages()` — `result.append(msg)` 应为                        
  `result.append(last)`，累积的非 Message item 被丢弃                                      
  4. `protocol.py` `to_channel_event()` **(主因)** — `exclude_unset=True` 忽略             
  `list.append()` 原地修改，`contents` 被静默丢弃                                          
                                                                                         
  ```python                                                                                
  # 最小复现                                                                             
  from pydantic import BaseModel, Field                                                    
  class Demo(BaseModel):                                                                   
      items: list[str] = Field(default_factory=list)                                       
  d = Demo()                                                                               
  d.items.append('hello')                                                                
  d.model_dump_json(exclude_unset=True)  # -> {} items 丢失                                
                                                                                           
  Changes                                                                                  
                                                                                           
  ┌───────────────────────────────────────────────────┬────────────────────────────────┐   
  │                       文件                        │              改动              │ 
  ├───────────────────────────────────────────────────┼────────────────────────────────┤   
  │                                                   │ wrap_content() 加 .to_content( │ 
  │ src/ghoshell_moss/message/message.py              │ )；content_as_string()         │   
  │                                                   │ 防御式访问                     │   
  ├───────────────────────────────────────────────────┼────────────────────────────────┤ 
  │ src/ghoshell_moss/core/py_channel.py              │ _wrap_messages() 变量修正      │   
  ├───────────────────────────────────────────────────┼────────────────────────────────┤   
  │ src/ghoshell_moss/core/duplex/protocol.py         │ to_channel_event() 删除        │ 
  │                                                   │ exclude_unset=True             │   
  ├───────────────────────────────────────────────────┼────────────────────────────────┤ 
  │ tests/ghoshell_moss/core/ctml/shell/test_shell_im │ 新增 10 个测试                 │   
  │ age.py                                            │                                │   
  └───────────────────────────────────────────────────┴────────────────────────────────┘
                                                                                           
  Test Plan                                                                              

  - 18 个已有 thread channel 测试通过                                                      
  - 4 个已有 speech 测试通过
  - 10 个新增图片测试通过，覆盖 shell 命令返回图片、context_messages 返回图片、JSON        
  序列化往返、全链路 bridge 集成测试                                                       
                                                                                           
  via claude code                                                                          
  ```