### PR TITLE
fix: sync _cell_address on set_mode to preserve host cell identity

### DIFF
--- a/.ai_partners/features/workstreams/2026/06/cell-address-mode-sync/FEATURE.md
+++ b/.ai_partners/features/workstreams/2026/06/cell-address-mode-sync/FEATURE.md
@@ -1,0 +1,43 @@
+---
+created: 2026-06-04
+depends: []
+description: 'Fix: Environment.set_mode() must sync _cell_address so MatrixImpl correctly
+  identifies the host cell, enabling cross-process channel discovery for apps brought
+  up by a mode.'
+milestone: null
+priority: P1
+status: in-progress
+status_note: root cause identified, fix applied to Environment.set_mode()
+title: Cell Address Mode Sync
+updated: '2026-06-04'
+---
+
+# Cell Address Mode Sync
+
+## Motivation
+
+`moss-run-ghost echo --mode douyin_chat` 启动 Ghost 后，Ghost 进程发现不了
+mode 通过 `bringup_apps` 启动的两个 app 的 channel。
+
+根因：`Environment.set_mode()` 只更新 `_moss_mode`，没有同步更新 `_cell_address`。
+当 mode 在 `Environment.__init__` 之后通过 `set_mode()` 变更时，`_cell_address`
+保持初始 mode 的值（如 `host/default`），而 `MatrixImpl` 中 `main_cell.address`
+基于实际 Mode 对象计算（`host/douyin_chat`）。两者不匹配导致 `_is_main` 判定为
+False，`channel_proxy()` 被阻止，AppStoreChannel 无法为 app 创建 Zenoh 代理 channel。
+
+## Key Decisions
+
+1. **在 `set_mode()` 内同步 `_cell_address`**，而非在 `MatrixImpl` 内做容错。
+   理由：`_cell_address` 是 Environment 的派生属性，保持 self-consistent 是
+   Environment 的职责。MatrixImpl 不应该猜测 cell_address 是否正确。
+
+2. **仅当 `MOSS_CELL_ADDRESS` 未显式设置时才更新**。App 进程通过 `MOSS_CELL_ADDRESS`
+   显式指定自己的 cell_address（如 `app/group/name`），`set_mode` 不应覆盖。
+   Host 进程的 cell_address 从模板派生，mode 变更时必须同步。
+
+## Implementation Notes
+
+- 修改文件：`src/ghoshell_moss/core/blueprint/environment.py` (`set_mode` 方法)
+- 新增测试：`tests/ghoshell_moss/host/test_environment_set_mode.py` (3 cases)
+- 关联修改：`src/ghoshell_moss/host/matrix.py` (同一轮修复的配套改动 —— 将
+  `DEFAULT_CELL_ADDRESS` 模板比较改为与 `main_cell.address` 的实际值比较)

--- a/src/ghoshell_moss/core/blueprint/environment.py
+++ b/src/ghoshell_moss/core/blueprint/environment.py
@@ -203,6 +203,11 @@ class Environment:
     def set_mode(self, mode: str) -> None:
         self._moss_mode = mode
         os.environ[ENV_MOSS_MODE_KEY] = mode
+        # 如果 cell_address 是从默认模板派生的（而非通过 MOSS_CELL_ADDRESS 显式指定），
+        # 则在 mode 变更时同步更新。否则 host 进程的 cell_address 与 main_cell.address
+        # 不匹配，导致 _is_main 判定为 False，channel_proxy() 被阻止。
+        if ENV_CELL_ADDRESS_KEY not in os.environ:
+            self._cell_address = DEFAULT_CELL_ADDRESS.format(mode=mode)
 
     def set_session_scope(self, session_scope: str) -> None:
         self._session_scope = session_scope

--- a/src/ghoshell_moss/host/matrix.py
+++ b/src/ghoshell_moss/host/matrix.py
@@ -16,7 +16,7 @@ from ghoshell_moss.core.blueprint.manifests import Manifests
 from ghoshell_moss.core.blueprint.matrix import Matrix, Cell, MatrixLifecycleObject
 from ghoshell_moss.core.blueprint.app import AppStore, AppInfo
 from ghoshell_moss.core.blueprint.host import Mode
-from ghoshell_moss.core.blueprint.environment import Environment, DEFAULT_CELL_ADDRESS
+from ghoshell_moss.core.blueprint.environment import Environment
 from ghoshell_moss.core.blueprint.host import MossSystemPrompter
 from ghoshell_moss.core.concepts.channel import Channel
 from ghoshell_moss.core.concepts.topic import TopicService
@@ -131,12 +131,9 @@ class MatrixImpl(Matrix):
         cell_alive_events[main_cell.address] = event
         cells[main_cell.address] = main_cell
         self._main_cell = main_cell
-        if self._this_cell_address == DEFAULT_CELL_ADDRESS:
-            self._this_cell_address = main_cell.address
-            self._is_main = True
+        if self._this_cell_address == main_cell.address:
             self._this_cell = main_cell
         else:
-            # 其实不会有 unknown, 不过开发测试阶段, 做一个兜底.
             self._this_cell = cells.get(
                 self._this_cell_address,
                 UnknownCell(),
@@ -163,6 +160,13 @@ class MatrixImpl(Matrix):
         self._system_prompter = self._prepare_system_prompter()
         self._container = self._prepare_container()
         self._lifecycle_bound_objects_or_types: list[MatrixLifecycleObject | Type[MatrixLifecycleObject]] = []
+
+        if isinstance(self._this_cell, UnknownCell):
+            log = self._logger or self.env.logger
+            log.warning(
+                "%s cell address %r not found in known cells: %s, fallback to UnknownCell",
+                self._log_prefix, self._this_cell_address, list(cells.keys()),
+            )
 
     def _prepare_system_prompter(self) -> SystemPrompter:
         from ghoshell_moss.host.system_prompter import MossSystemPrompterImpl

--- a/tests/ghoshell_moss/host/test_environment_set_mode.py
+++ b/tests/ghoshell_moss/host/test_environment_set_mode.py
@@ -1,0 +1,46 @@
+"""set_mode() must update _cell_address when derived from template."""
+
+import os
+import pytest
+from pathlib import Path
+
+from ghoshell_moss.core.blueprint.environment import (
+    Environment, DEFAULT_CELL_ADDRESS, ENV_CELL_ADDRESS_KEY, ENV_MOSS_MODE_KEY,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env():
+    """清理可能影响测试的环境变量."""
+    old = {k: os.environ.pop(k, None) for k in [ENV_MOSS_MODE_KEY, ENV_CELL_ADDRESS_KEY]}
+    yield
+    for k, v in old.items():
+        if v is not None:
+            os.environ[k] = v
+
+
+def test_set_mode_updates_cell_address_from_template(tmp_path):
+    """当 cell_address 从模板派生时，set_mode 应同步更新."""
+    env = Environment(workspace_path=tmp_path, mode="initial")
+    assert env.cell_address == DEFAULT_CELL_ADDRESS.format(mode="initial")
+
+    env.set_mode("new_mode")
+    assert env.moss_mode_name == "new_mode"
+    assert env.cell_address == DEFAULT_CELL_ADDRESS.format(mode="new_mode")
+
+
+def test_set_mode_preserves_explicit_cell_address(tmp_path):
+    """当 MOSS_CELL_ADDRESS 显式指定时，set_mode 不应覆盖."""
+    os.environ[ENV_CELL_ADDRESS_KEY] = "fractal/remote_node"
+    env = Environment(workspace_path=tmp_path, mode="initial")
+    assert env.cell_address == "fractal/remote_node"
+
+    env.set_mode("new_mode")
+    assert env.cell_address == "fractal/remote_node"
+
+
+def test_set_mode_no_env_var_means_template_derived(tmp_path):
+    """无 MOSS_CELL_ADDRESS 环境变量时，cell_address 来自模板."""
+    assert ENV_CELL_ADDRESS_KEY not in os.environ
+    env = Environment(workspace_path=tmp_path, mode="test")
+    assert env.cell_address == "host/test"

--- a/tests/ghoshell_moss/host/test_matrix_init.py
+++ b/tests/ghoshell_moss/host/test_matrix_init.py
@@ -1,0 +1,175 @@
+"""MatrixImpl.__init__ cell address 解析和 _is_main 判定。
+
+覆盖: DEFAULT_CELL_ADDRESS 从 'main' 改为 'host/{mode}' 后，
+MatrixImpl 仍能正确识别主 cell 身份。
+"""
+
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+from ghoshell_moss.core.blueprint.matrix import Mode, Manifests
+from ghoshell_moss.core.blueprint.environment import Environment, DEFAULT_CELL_ADDRESS
+from ghoshell_moss.host.matrix import MatrixImpl, HostCell, UnknownCell
+from ghoshell_moss.contracts.workspace import LocalWorkspace
+
+
+@pytest.fixture
+def mode():
+    return Mode(name="test_mode", description="A test mode")
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    ws = LocalWorkspace(tmp_path)
+    ws.root_path().mkdir(parents=True, exist_ok=True)
+    return ws
+
+
+@pytest.fixture
+def env(workspace, mode):
+    return Environment(workspace_path=workspace.root_path(), mode=mode.name)
+
+
+@pytest.fixture
+def app_store():
+    store = MagicMock()
+    store.list_apps.return_value = []
+    return store
+
+
+@pytest.fixture
+def manifest():
+    m = MagicMock()
+    m.ctml_versions.return_value = {"v1_0_0.zh": MagicMock()}
+    m.channels.return_value = {}
+    return m
+
+
+# ------------------------------------------------------------------
+# 默认 cell address — 无 MOSS_CELL_ADDRESS 环境变量
+# ------------------------------------------------------------------
+
+
+def test_default_cell_address_is_host_mode(env, mode):
+    """无 MOSS_CELL_ADDRESS 时，默认 cell_address = 'host/{mode}' 格式化后的值."""
+    assert env.cell_address == f"host/{mode.name}"
+
+
+def test_default_cell_address_does_not_equal_template(env, mode):
+    """格式化后的 cell address ('host/test_mode') != 模板字符串 ('host/{mode}')."""
+    assert env.cell_address != DEFAULT_CELL_ADDRESS
+
+
+# ------------------------------------------------------------------
+# MatrixImpl._this_cell / _is_main 判定
+# ------------------------------------------------------------------
+
+
+def _make_matrix(mode, env, workspace, app_store, manifest):
+    """构造 MatrixImpl，绕过 _prepare_system_prompter 的 CTML 文件依赖."""
+    with patch.object(MatrixImpl, '_prepare_system_prompter', return_value=MagicMock()):
+        return MatrixImpl(
+            mode=mode,
+            env=env,
+            app_store=app_store,
+            manifest=manifest,
+            workspace=workspace,
+        )
+
+
+def test_is_main_true_when_cell_address_matches_host_cell(mode, env, workspace, app_store, manifest):
+    """默认情况下，env.cell_address == main_cell.address，_is_main 应为 True."""
+    matrix = _make_matrix(mode, env, workspace, app_store, manifest)
+    assert matrix._is_main is True
+    assert isinstance(matrix.this, HostCell)
+    assert matrix.this.type == "host"
+
+
+def test_is_main_true_even_if_branch_comparison_is_broken(mode, env, workspace, app_store, manifest):
+    """验证: 即使 DEFAULT_CELL_ADDRESS 模板比较失效，
+    cells.get() 回退分支仍能通过 address 匹配找到 HostCell。
+    """
+    env_cell = env.cell_address
+    assert env_cell != DEFAULT_CELL_ADDRESS  # 模板比较永不成立
+
+    matrix = _make_matrix(mode, env, workspace, app_store, manifest)
+
+    # 因为 env_cell == main_cell.address，cells.get() 应该找到 HostCell
+    assert matrix._is_main is True
+    assert matrix.this.type == "host"
+
+
+def test_is_main_false_when_cell_address_is_unknown(mode, workspace, app_store, manifest, tmp_path):
+    """当 MOSS_CELL_ADDRESS 指向未知地址时，回退为 UnknownCell，_is_main = False."""
+    unknown_addr = "fractal/some_remote_node"
+
+    os.environ["MOSS_CELL_ADDRESS"] = unknown_addr
+    try:
+        env2 = Environment(workspace_path=tmp_path, mode=mode.name)
+        assert env2.cell_address == unknown_addr
+
+        matrix = _make_matrix(mode, env2, workspace, app_store, manifest)
+        assert matrix._is_main is False
+        assert isinstance(matrix.this, UnknownCell)
+        assert matrix.this.type == "unknown"
+    finally:
+        del os.environ["MOSS_CELL_ADDRESS"]
+
+
+def test_is_main_true_when_address_matches_first_cell(mode, env, workspace, app_store, manifest):
+    """当 MOSS_CELL_ADDRESS 匹配 cells dict 中的某个 app cell 时，
+    该 cell 被找到但不是 HostCell，_is_main 应为 False。
+    """
+    from ghoshell_moss.core.blueprint.app import AppInfo, AppWatcher
+
+    app = AppInfo(
+        name="test_app", group="tools",
+        description="test", work_directory="/tmp",
+        watcher=AppWatcher(),
+    )
+    app_store.list_apps.return_value = [app]
+
+    os.environ["MOSS_CELL_ADDRESS"] = app.address
+    try:
+        env2 = Environment(workspace_path=workspace.root_path(), mode=mode.name)
+        assert env2.cell_address == app.address
+
+        matrix = _make_matrix(mode, env2, workspace, app_store, manifest)
+        # 找到了 AppCell，不是 HostCell
+        assert matrix._is_main is False
+        assert matrix.this.type == "app"
+    finally:
+        del os.environ["MOSS_CELL_ADDRESS"]
+
+
+# ------------------------------------------------------------------
+# channel_proxy 守卫
+# ------------------------------------------------------------------
+
+
+def test_channel_proxy_raises_when_not_main_cell(mode, workspace, app_store, manifest, tmp_path):
+    """非主 cell 调用 channel_proxy 应抛出 RuntimeError."""
+    os.environ["MOSS_CELL_ADDRESS"] = "fractal/some_remote_node"
+    try:
+        env2 = Environment(workspace_path=tmp_path, mode=mode.name)
+        matrix = _make_matrix(mode, env2, workspace, app_store, manifest)
+        matrix._check_running = MagicMock()  # bypass _check_running
+
+        assert matrix._is_main is False
+        with pytest.raises(RuntimeError, match="Only allowed in main cell type"):
+            matrix.channel_proxy(address="app/test/foo", name="proxy")
+    finally:
+        del os.environ["MOSS_CELL_ADDRESS"]
+
+
+def test_channel_proxy_succeeds_when_main_cell(mode, env, workspace, app_store, manifest):
+    """主 cell 调用 channel_proxy 不因 _is_main 守卫而抛异常."""
+    matrix = _make_matrix(mode, env, workspace, app_store, manifest)
+    matrix._check_running = MagicMock()
+    assert matrix._is_main is True
+
+    # Zenoh session 未启动所以后续会失败，但守卫检查在之前且通过
+    with pytest.raises(Exception) as exc_info:
+        matrix.channel_proxy(address="app/test/foo", name="proxy")
+    assert "Only allowed in main cell type" not in str(exc_info.value)


### PR DESCRIPTION
  ## Summary                                                                                                                                                     
   
  - **根因**：`Environment.set_mode()` 只更新 `_moss_mode`，不同步 `_cell_address`。当 mode 在 `__init__` 之后通过 `set_mode()` 变更时，`_cell_address`          
  仍保持初始值（如 `host/default`），而 `MatrixImpl` 中 `main_cell.address` 基于实际 Mode 计算（如 `host/douyin_chat`）。两者不匹配 → `_is_main` 判定为 False →
  `channel_proxy()` 被阻止 → Ghost 进程发现不了 mode 通过 `bringup_apps` 启动的 app channel。                                                                    
                                                                                                                                                               
  - **修复**：`set_mode()` 内同步 `_cell_address`，仅当 `MOSS_CELL_ADDRESS` 未显式设置时才更新（app 进程通过该环境变量指定自己的 cell_address，不应被覆盖）。    
   
  - **配套改动**：`MatrixImpl.__init__` 中将 `DEFAULT_CELL_ADDRESS` 模板字符串比较改为与 `main_cell.address` 实际值比较，并在 `UnknownCell` 回退时输出 warning   
  日志。                                                                                                                                                       
                                                                                                                                                                 
  ## Changed files                                                                                                                                               
   
  | File | Change |                                                                                                                                              
  |---|---|                                                                                                                                                    
  | `src/ghoshell_moss/core/blueprint/environment.py` | `set_mode()` 新增 `_cell_address` 同步逻辑（3 行） |                                                     
  | `src/ghoshell_moss/host/matrix.py` | 移除 `DEFAULT_CELL_ADDRESS` 模板比较，改为值比较；`UnknownCell` 时加 warning |                                          
  | `cell-address-mode-sync/FEATURE.md` | 根因分析、决策记录、实现备注 |                                                                                         
  | `tests/ghoshell_moss/host/test_environment_set_mode.py` | 3 个 case：模板派生同步、显式指定不覆盖、无环境变量行为 |                                          
  | `tests/ghoshell_moss/host/test_matrix_init.py` | 7 个 case：`_is_main` 判定、`channel_proxy` 守卫、`UnknownCell` 回退 |                                      
                                                                                                                                                                 
  ## Test plan                                                                                                                                                   
                                                                                                                                                                 
  - [x] `pytest tests/ghoshell_moss/host/test_environment_set_mode.py -v`                                                                                        
  - [x] `pytest tests/ghoshell_moss/host/test_matrix_init.py -v`                                                                                               
  - [x] `moss-run-ghost echo --mode <含bringup_apps的mode>` —— Ghost 能发现 app channel  