### PR TITLE
feat: add audio capture source with miniaudio backend and waveform app

### DIFF
--- a/.ai_partners/features/workstreams/2026/06/audio-capture/FEATURE.md
+++ b/.ai_partners/features/workstreams/2026/06/audio-capture/FEATURE.md
@@ -4,10 +4,10 @@ depends: []
 description: 基于 miniaudio 的系统音频捕获源，原始 PCM 经 Zenoh 广播，消费者按需加工（波形可视化、ASR、剪辑）。 ConfigType 格式共识 + tmp_storage 运行时发现 + Provider 注入。
 milestone: null
 priority: P1
-status: draft
-status_note: 补充 SequentialAudioConsumer 设计与 listener 依赖关系，交由 AI 实例实现
+status: in-progress
+status_note: 全部 5 步完成，MatrixLifecycleObject 自动启停，waveform App 跨进程消费已验证
 title: Audio Capture — 系统音频感知通道
-updated: '2026-06-04'
+updated: '2026-06-05'
 ---
 
 # Audio Capture
@@ -30,13 +30,14 @@ updated: '2026-06-04'
 
 ## Design Index
 
-- Contract: `ghoshell_moss.contracts.audio`（待创建）
-- 实现: `ghoshell_moss.host.speech.capture.miniaudio_capture`（待创建）
-- Provider: `ghoshell_moss.host.providers.audio_capture_provider`（待创建）
+- Contract: `ghoshell_moss.contracts.audio` — 7 个符号
+- 实现: `ghoshell_moss.host.speech.capture.miniaudio_capture` — MiniAudioCaptureSource + 消费者
+- Provider: `ghoshell_moss.host.providers.audio_capture_provider` — singleton + IoC
+- 生命周期: `Host.__init__` 注册 `AudioCaptureSource` 为 `MatrixLifecycleObject`，随 Matrix 自动启停
 - 播放端对称参考: `ghoshell_moss.host.speech.player.miniaudio_player:MiniAudioStreamPlayer`
 - 播放 Provider 参考: `ghoshell_moss.host.providers.audio_player_provider:AudioPlayerProvider`
-- 进程锁: `ghoshell_moss.contracts.workspace:FileLocker`
-- 下游消费 feature: listener（ASR 消费者）、波形 Channel（可视化消费者）
+- 进程锁: `ghoshell_moss.contracts.workspace:FileLocker`（跨进程防重复打开设备）
+- 下游消费: waveform App（`.moss_ws/apps/sensors/waveform/`）、listener（ASR 消费者，待实现）
 
 ## Key Decisions
 
@@ -239,21 +240,104 @@ class AudioSequentialConsumer(ABC):
 
 ## Implementation Notes
 
-### 实现顺序
+### 实施进度
 
-1. `contracts/audio.py` — 所有抽象定义（含 `AudioSequentialConsumer`）
-2. `host/speech/capture/miniaudio_capture.py` — MiniAudioCaptureSource 实现（含 `MiniAudioSequentialConsumer`）
-3. `host/providers/audio_capture_provider.py` — Provider 注册
-4. 波形 Channel（后续 feature）
-5. listener（后续 feature，依赖 `AudioSequentialConsumer`）
+| Step | 内容 | 状态 | 日期 |
+|------|------|------|------|
+| 1 | `contracts/audio.py` — 抽象定义 | **done** | 2026-06-05 |
+| 2 | `host/speech/capture/miniaudio_capture.py` — 核心实现 | **done** | 2026-06-05 |
+| 3 | `host/providers/audio_capture_provider.py` — Provider + manifests | **done** | 2026-06-05 |
+| 4 | Waveform App（`.moss_ws/apps/sensors/waveform/`）— 跨进程可视化消费者 | **done** | 2026-06-05 |
+| 5 | MatrixLifecycleObject 集成 — 随 Matrix 自动启停 | **done** | 2026-06-05 |
+| 6 | listener（ASR 消费者，后续 feature，依赖 `AudioSequentialConsumer`） | pending | |
+
+### Step 1-2 实现细节
+
+**contracts/audio.py** — 7 个符号，已在 `contracts/__init__.py` 中导出：
+
+- `AudioFrameMeta(BaseModel)` — rms_db, bands(bass/mid/high), is_silent
+- `AudioChunk(BaseModel)` — seq, timestamp, samples(ndarray), meta
+- `AudioCaptureConfig(ConfigType)` — conf_name="audio_capture"，默认 44100Hz/mono/pcm_s16le/50ms/blackhole
+- `AudioRuntimeInfo(BaseModel)` — running, stream_key, device_name, device_explain, started_at, last_heartbeat
+- `AudioCaptureSource(ABC)` — start(), device_explain(), new_consumer(), new_sequential_consumer(), close()
+- `AudioPullLatest(ABC)` — pull_latest(), close()
+- `AudioSequentialConsumer(ABC)` — start(), close(), \_\_aiter\_\_()/\_\_anext\_\_()
+
+**host/speech/capture/miniaudio_capture.py** — 核心实现：
+
+- `MiniAudioCaptureSource` — miniaudio CaptureDevice callback generator 模式（与 PlaybackDevice 对称），FFT 在回调线程中计算，AudioChunk 序列化后通过 `session.pub_stream_delta()` 发布到 Zenoh
+- `_MiniAudioPullLatest` — ring buffer（collections.deque maxlen），`session.sub_stream()` 回调写入，`pull_latest()` 非阻塞读
+- `MiniAudioSequentialConsumer` — 封装 `session.get_stream()` + `StreamSubscriber`，janus.Queue 桥接线程，`async for` 消费
+- `_compute_frame_meta()` — RMS + 3-band FFT (bass/mid/high) + 静音判定（阈值 -50dB）
+- `_pack_chunk()` / `_unpack_chunk()` — 二进制序列化：`[4B meta_len(uint32 BE)][JSON meta UTF-8][PCM int16 LE]`
+- `start()` 通过 `ws.lock("audio_capture")` 拿进程锁
+- `_write_runtime_info()` 将 `AudioRuntimeInfo` 写入 `session.tmp_storage`
 
 ### miniaudio CaptureDevice 回调模式
 
-和 `MiniAudioStreamPlayer._make_generator()` 对称，使用 miniaudio 的 callback/ring buffer 模式。miniaudio 回调在独立线程中触发，需线程安全地将 PCM 写入 ring buffer，Zenoh pub 在 asyncio 侧读取。
+和 `MiniAudioStreamPlayer._make_generator()` 对称，使用 miniaudio 的 callback generator 模式。miniaudio 在内部线程中通过 `gen.send(raw_bytes)` 传递捕获的 PCM 数据。回调中直接计算 FFT、序列化、Zenoh pub——Zenoh session 本身线程安全，无需额外桥接。
 
 ### 设备发现
 
 `device_pattern` 用于匹配设备名。枚举所有 `miniaudio.devices()` 中 `is_default=False` 且名称匹配的 capture 设备。若无匹配，fallback 到默认输入设备。
+
+### Step 3: Provider + manifests
+
+**`host/providers/audio_capture_provider.py`** — `AudioCaptureProvider(Provider[AudioCaptureSource])`，singleton=True。factory 从 IoC 获取 Matrix + ConfigStore，创建 `MiniAudioCaptureSource`。
+
+**manifests 注册**：
+- `.moss_ws/src/MOSS/manifests/providers.py` — `capture_source_provider = AudioCaptureProvider()`
+- `.moss_ws/src/MOSS/manifests/configs.py` — `audio_capture_config = AudioCaptureConfig()`
+
+### Step 4: Waveform App（跨进程消费者）
+
+**`.moss_ws/apps/sensors/waveform/`** — 独立 MOSS App，通过 `session.get_stream("audio/pcm")` 跨进程订阅 Zenoh PCM 流。只解析 metadata（RMS + 3-band），终端渲染 unicode 波形条。验证了 capture → Zenoh → 跨进程消费者的完整链路。
+
+启动：`moss apps test sensors/waveform`
+
+渲染：40 字符宽 bar（`█` + 末位 1/8 精度部分块 `▏▎▍▌▋▊▉`），bass/mid/high + RMS 四行各自独立 bar。dB 范围 -60~0 dBFS，-50 dBFS 以下标 silent。
+
+### 实测 Bug 修复 (2026-06-05)
+
+**Bug 1: int16 样本未归一化导致 dB 值错误**。`_compute_frame_meta()` 直接将 int16 样本（值域 -32768~32767）cast 为 float64 后算 RMS，未除以 32768.0 归一化到 [-1, 1]，导致 dB 值为正数十 dB 的无意义值。修复：`samples.astype(np.float64) / 32768.0`，dB 变为标准 dBFS（0 = 满幅，负数 = 低于满幅）。`miniaudio_capture.py:41`。
+
+**Bug 2: 波形渲染只有 1 字符宽**。每个频段只用单个 Unicode bar 字符（`▃`），视觉上几乎无波动。修复：改为 40 字符宽 bar，末位用部分块字符（`▏▎▍▌▋▊▉█`）做 1/8 精度平滑过渡，四行（bass/mid/high/rms）各自独立 bar。`main.py`。
+
+### Step 5: MatrixLifecycleObject 集成
+
+**问题**：capture 需要随 Ghost 启动自动开启，而非手动控制。
+
+**方案**：`MiniAudioCaptureSource` 实现 `MatrixLifecycleObject` 协议（`__aenter__`/`__aexit__` 委派给 `start()`/`close()`）。在 `Host.__init__` 中注册 `AudioCaptureSource` 类型为生命周期对象。Matrix 启动时从 IoC 获取 singleton，自动进入 async context → `start()`；Matrix 关闭时自动 `close()`。
+
+**进程锁容错**：App 进程也会创建 Matrix 并触发生命周期。`start()` 在锁已被主进程持有时优雅跳过（log warning，不抛异常），App 仅订阅 Zenoh 流，不重复开设备。
+
+**Bug 修复**：`host/matrix.py:681` 将 `lifecycle`（类型）改为 `lifecycle_obj`（实例），修复类型注册时对 ABC 类调 `enter_async_context` 的 TypeError。
+
+### 当前架构总览
+
+```
+Host.__init__
+  └─ matrix.register_lifecycle_objects(AudioCaptureSource)
+
+Matrix.__aenter__
+  └─ container.get(AudioCaptureSource)
+       └─ AudioCaptureProvider.factory()
+            └─ MiniAudioCaptureSource(matrix, config)
+                 └─ __aenter__() → start()
+                      ├─ FileLocker.acquire()  # 进程锁
+                      ├─ miniaudio.CaptureDevice.start(gen)
+                      │    └─ callback: FFT → pack_chunk → session.pub_stream_delta("audio/pcm")
+                      └─ _write_runtime_info() → tmp_storage
+
+Waveform App (独立进程)
+  └─ session.get_stream("audio/pcm")
+       └─ async for sample → unpack metadata → 终端波形渲染
+
+Matrix.__aexit__
+  └─ MiniAudioCaptureSource.__aexit__() → close()
+       ├─ CaptureDevice.stop/close
+       └─ FileLocker.release()
+```
 
 ### 与 speech-governance feature 的关系
 
@@ -263,3 +347,5 @@ class AudioSequentialConsumer(ABC):
 
 *架构设计: DeepSeek V4 与人类工程师, 2026-06-03*
 *补充: SequentialAudioConsumer 设计、listener 依赖关系、运行时稳定性约束 — Claude Opus 4.7 与人类工程师, 2026-06-04*
+*实现: Step 1-2 contracts + miniaudio capture core — Claude Opus 4.7 与人类工程师, 2026-06-05*
+*Bug 修复: int16 归一化 + 波形渲染宽 bar — Claude Opus 4.7 与人类工程师, 2026-06-05*

--- a/.ai_partners/features/workstreams/2026/06/audio-capture/FEATURE.md
+++ b/.ai_partners/features/workstreams/2026/06/audio-capture/FEATURE.md
@@ -33,7 +33,7 @@ updated: '2026-06-05'
 - Contract: `ghoshell_moss.contracts.audio` — 7 个符号
 - 实现: `ghoshell_moss.host.speech.capture.miniaudio_capture` — MiniAudioCaptureSource + 消费者
 - Provider: `ghoshell_moss.host.providers.audio_capture_provider` — singleton + IoC
-- 生命周期: `Host.__init__` 注册 `AudioCaptureSource` 为 `MatrixLifecycleObject`，随 Matrix 自动启停
+- 生命周期: 独立 App（`.moss_ws/apps/sensors/audio_capture/`）— Ghost 通过 `apps:start`/`apps:stop` 控制启停，不再随 Matrix 自动拉起
 - 播放端对称参考: `ghoshell_moss.host.speech.player.miniaudio_player:MiniAudioStreamPlayer`
 - 播放 Provider 参考: `ghoshell_moss.host.providers.audio_player_provider:AudioPlayerProvider`
 - 进程锁: `ghoshell_moss.contracts.workspace:FileLocker`（跨进程防重复打开设备）
@@ -248,7 +248,7 @@ class AudioSequentialConsumer(ABC):
 | 2 | `host/speech/capture/miniaudio_capture.py` — 核心实现 | **done** | 2026-06-05 |
 | 3 | `host/providers/audio_capture_provider.py` — Provider + manifests | **done** | 2026-06-05 |
 | 4 | Waveform App（`.moss_ws/apps/sensors/waveform/`）— 跨进程可视化消费者 | **done** | 2026-06-05 |
-| 5 | MatrixLifecycleObject 集成 — 随 Matrix 自动启停 | **done** | 2026-06-05 |
+| 5 | Audio Capture App（`.moss_ws/apps/sensors/audio_capture/`）— 独立生命周期，Ghost 可控启停 | **done** | 2026-06-05 |
 | 6 | listener（ASR 消费者，后续 feature，依赖 `AudioSequentialConsumer`） | pending | |
 
 ### Step 1-2 实现细节
@@ -303,40 +303,37 @@ class AudioSequentialConsumer(ABC):
 
 **Bug 2: 波形渲染只有 1 字符宽**。每个频段只用单个 Unicode bar 字符（`▃`），视觉上几乎无波动。修复：改为 40 字符宽 bar，末位用部分块字符（`▏▎▍▌▋▊▉█`）做 1/8 精度平滑过渡，四行（bass/mid/high/rms）各自独立 bar。`main.py`。
 
-### Step 5: MatrixLifecycleObject 集成
+### Step 5: Audio Capture App（独立生命周期）
 
-**问题**：capture 需要随 Ghost 启动自动开启，而非手动控制。
+**设计决策**：capture 不随 Matrix 自动启停，而是独立 App，由 Ghost 通过 `apps:start sensors/audio_capture` / `apps:stop sensors/audio_capture` 控制。原因：capture 是可选能力，不是每次 Matrix 启动都需要打开麦克风，应像波形可视化一样按需拉起。
 
-**方案**：`MiniAudioCaptureSource` 实现 `MatrixLifecycleObject` 协议（`__aenter__`/`__aexit__` 委派给 `start()`/`close()`）。在 `Host.__init__` 中注册 `AudioCaptureSource` 类型为生命周期对象。Matrix 启动时从 IoC 获取 singleton，自动进入 async context → `start()`；Matrix 关闭时自动 `close()`。
+**方案**：创建 `.moss_ws/apps/sensors/audio_capture/`，入口 `main.py` 获取 Matrix → 创建 `MiniAudioCaptureSource` → `start()` → `stop_event.wait()` 阻塞 → 收到信号后 `close()`。从 `host/impl.py` 移除 `register_lifecycle_objects(AudioCaptureSource)`，从 `MiniAudioCaptureSource` 移除 `__aenter__`/`__aexit__`。
 
-**进程锁容错**：App 进程也会创建 Matrix 并触发生命周期。`start()` 在锁已被主进程持有时优雅跳过（log warning，不抛异常），App 仅订阅 Zenoh 流，不重复开设备。
+**早期方案（已废弃）**: MatrixLifecycleObject 集成。`MiniAudioCaptureSource` 实现 `MatrixLifecycleObject` 协议，`Host.__init__` 注册 `AudioCaptureSource` 类型，Matrix 启动时自动进入 async context。废弃原因：capture 与 Matrix 生命周期过度耦合，Ghost 无法控制捕获启停。
 
 **Bug 修复**：`host/matrix.py:681` 将 `lifecycle`（类型）改为 `lifecycle_obj`（实例），修复类型注册时对 ABC 类调 `enter_async_context` 的 TypeError。
 
 ### 当前架构总览
 
 ```
-Host.__init__
-  └─ matrix.register_lifecycle_objects(AudioCaptureSource)
-
-Matrix.__aenter__
-  └─ container.get(AudioCaptureSource)
-       └─ AudioCaptureProvider.factory()
+Ghost: apps:start sensors/audio_capture
+  └─ Audio Capture App (独立进程)
+       └─ Matrix.discover().run(main)
             └─ MiniAudioCaptureSource(matrix, config)
-                 └─ __aenter__() → start()
+                 └─ start()
                       ├─ FileLocker.acquire()  # 进程锁
                       ├─ miniaudio.CaptureDevice.start(gen)
                       │    └─ callback: FFT → pack_chunk → session.pub_stream_delta("audio/pcm")
                       └─ _write_runtime_info() → tmp_storage
+                 └─ stop_event.wait()  # 阻塞，等待停止信号
+                 └─ close()  # finally
 
 Waveform App (独立进程)
   └─ session.get_stream("audio/pcm")
        └─ async for sample → unpack metadata → 终端波形渲染
 
-Matrix.__aexit__
-  └─ MiniAudioCaptureSource.__aexit__() → close()
-       ├─ CaptureDevice.stop/close
-       └─ FileLocker.release()
+Ghost: apps:stop sensors/audio_capture
+  └─ 发送 SIGTERM → capture.close()
 ```
 
 ### 与 speech-governance feature 的关系

--- a/.moss_ws/apps/sensors/audio_capture/.gitignore
+++ b/.moss_ws/apps/sensors/audio_capture/.gitignore
@@ -1,0 +1,6 @@
+*.log
+venv/
+.venv/
+uv.lock
+.idea
+.env

--- a/.moss_ws/apps/sensors/audio_capture/APP.md
+++ b/.moss_ws/apps/sensors/audio_capture/APP.md
@@ -1,0 +1,8 @@
+---
+arguments: ''
+description: 'System audio capture — opens miniaudio CaptureDevice, publishes raw PCM to Zenoh stream (audio/pcm) with per-frame FFT metadata.'
+executable: uv
+respawn: false
+script: main.py
+workers: 1
+---

--- a/.moss_ws/apps/sensors/audio_capture/CLAUDE.md
+++ b/.moss_ws/apps/sensors/audio_capture/CLAUDE.md
@@ -1,0 +1,18 @@
+# MOSS App
+
+## 关键文件
+
+- `APP.md` — App 元信息声明
+- `main.py` — 入口脚本。获取 AudioCaptureSource，打开 miniaudio 设备，PCM → Zenoh
+- `CLAUDE.md` — 这个文件
+
+## 运行时
+
+```bash
+moss apps test sensors/audio_capture
+```
+
+## 消费者
+
+- waveform: `moss apps test sensors/waveform`
+- listener (ASR, 后续 feature)

--- a/.moss_ws/apps/sensors/audio_capture/main.py
+++ b/.moss_ws/apps/sensors/audio_capture/main.py
@@ -1,0 +1,39 @@
+"""Audio capture app — opens miniaudio CaptureDevice, publishes PCM to Zenoh.
+
+Usage:
+    moss apps test sensors/audio_capture
+    moss apps start sensors/audio_capture
+"""
+import asyncio
+import logging
+
+from ghoshell_moss.contracts.audio import AudioCaptureConfig
+from ghoshell_moss.core.blueprint.matrix import Matrix
+from ghoshell_moss.host.speech.capture.miniaudio_capture import MiniAudioCaptureSource
+
+
+async def main(matrix: Matrix) -> None:
+    logger = matrix.logger or logging.getLogger("moss.audio_capture")
+    logger.info("Audio capture app starting")
+
+    config = AudioCaptureConfig()
+    capture = MiniAudioCaptureSource(matrix=matrix, config=config)
+
+    await capture.start()
+    logger.info("Audio capture app started (device: %s)", capture.device_explain())
+
+    stop_event = asyncio.Event()
+
+    try:
+        await stop_event.wait()
+    except asyncio.CancelledError:
+        logger.info("Audio capture app cancelled, shutting down")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        await capture.close()
+        logger.info("Audio capture app stopped")
+
+
+if __name__ == "__main__":
+    Matrix.discover().run(main)

--- a/.moss_ws/apps/sensors/waveform/.gitignore
+++ b/.moss_ws/apps/sensors/waveform/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/.moss_ws/apps/sensors/waveform/APP.md
+++ b/.moss_ws/apps/sensors/waveform/APP.md
@@ -1,0 +1,8 @@
+---
+arguments: ''
+description: 'Terminal waveform visualization — subscribes to audio/pcm Zenoh stream, renders real-time level bars in terminal.'
+executable: uv
+respawn: false
+script: main.py
+workers: 1
+---

--- a/.moss_ws/apps/sensors/waveform/CLAUDE.md
+++ b/.moss_ws/apps/sensors/waveform/CLAUDE.md
@@ -1,0 +1,13 @@
+# MOSS App
+
+## 关键文件
+
+- `APP.md` — App 元信息声明
+- `main.py` — 入口脚本。接收 Matrix，通过 Session 订阅音频流，渲染波形
+- `CLAUDE.md` — 这个文件
+
+## 运行时
+
+```bash
+moss apps test sensors/waveform
+```

--- a/.moss_ws/apps/sensors/waveform/main.py
+++ b/.moss_ws/apps/sensors/waveform/main.py
@@ -1,0 +1,99 @@
+"""Waveform visualization app — subscribes to audio/pcm Zenoh stream, renders terminal bars.
+
+Usage:
+    moss apps test sensors/waveform
+    moss apps start sensors/waveform
+"""
+import asyncio
+import json
+import struct
+import sys
+import time
+
+from ghoshell_moss.core.blueprint.matrix import Matrix
+
+_STREAM_KEY = "audio/pcm"
+_FLOOR_DB = -60.0
+_CEILING_DB = 0.0
+_BAR_WIDTH = 40
+_PARTIALS = " ▏▎▍▌▋▊▉█"
+
+
+def _db_to_ratio(rms_db: float) -> float:
+    clamped = max(_FLOOR_DB, min(_CEILING_DB, rms_db))
+    return (clamped - _FLOOR_DB) / (_CEILING_DB - _FLOOR_DB)
+
+
+def _render_bar(value_db: float, width: int) -> str:
+    ratio = _db_to_ratio(value_db)
+    filled = ratio * width
+    full = int(filled)
+    rem = filled - full
+    bar = "█" * full
+    if full < width:
+        bar += _PARTIALS[int(rem * 8)]
+        bar += " " * (width - full - 1)
+    return bar
+
+
+def _unpack_meta(data: bytes) -> dict:
+    meta_len = struct.unpack(">I", data[:4])[0]
+    return json.loads(data[4:4 + meta_len])
+
+
+def _render_frame(meta: dict) -> str:
+    bands = meta.get("bands", {})
+    lines = []
+    for band in ["bass", "mid", "high"]:
+        db = bands.get(band, -96)
+        bar = _render_bar(db, _BAR_WIDTH)
+        lines.append(f"  {band:5s} {bar} {db:+.1f} dB")
+    rms = meta.get("rms_db", -96)
+    is_silent = meta.get("is_silent", True)
+    status = "(silent)" if is_silent else "(active)"
+    lines.append(f"  {'rms':5s} {_render_bar(rms, _BAR_WIDTH)} {rms:+.1f} dB {status}")
+    return "\n".join(lines)
+
+
+async def main(matrix: Matrix) -> None:
+    session = matrix.session
+    logger = matrix.logger
+    logger.info("Waveform app starting, subscribing to %s", _STREAM_KEY)
+
+    # Print header once
+    print("\033[2J\033[H", end="")
+    print("  Audio Waveform [bass | mid | high]\n")
+    # Reserve 5 lines for bars + 1 blank
+    for _ in range(5):
+        print()
+
+    stream = session.get_stream(_STREAM_KEY, maxsize=64)
+    frame_count = 0
+    start_time = time.time()
+
+    try:
+        async with stream:
+            async for sample in stream:
+                meta = _unpack_meta(sample.payload)
+                # Render bars starting at line 4
+                lines = _render_frame(meta).split("\n")
+                for i, line in enumerate(lines):
+                    print(f"\033[{4 + i};1H\033[K{line}", end="", flush=True)
+                frame_count += 1
+
+    except asyncio.CancelledError:
+        pass
+    except KeyboardInterrupt:
+        pass
+    finally:
+        elapsed = time.time() - start_time
+        fps = frame_count / elapsed if elapsed > 0 else 0
+        print(f"\n\n  Stopped. {frame_count} frames in {elapsed:.1f}s ({fps:.0f} fps)")
+
+
+if __name__ == "__main__":
+    try:
+        Matrix.discover().run(main)
+    except KeyboardInterrupt:
+        print("\nWaveform app stopped.")
+        sys.exit(0)

--- a/.moss_ws/apps/sensors/waveform/uv.lock
+++ b/.moss_ws/apps/sensors/waveform/uv.lock
@@ -1,0 +1,528 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "ghoshell-common"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "ghoshell-container" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/56/2ae15f24c25650f0755433856613fb7e9976a1b5f3837421f43f90232c00/ghoshell_common-0.5.0.tar.gz", hash = "sha256:c66c62e4a11fedc6fcdfc6230b7c805e3e6bf9792dbea4786d99f599e87582d0", size = 30240, upload-time = "2026-02-06T10:18:34.48Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/75/cce51508b07e1fa1dcd88f8124fd875183490fc80080afd1b7ffa773564c/ghoshell_common-0.5.0-py3-none-any.whl", hash = "sha256:2e2df2fd6b8618f9f18c3603096ae616fa64016af9c08ab858a2278351621974", size = 35265, upload-time = "2026-02-06T10:18:22.838Z" },
+]
+
+[[package]]
+name = "ghoshell-container"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/1f/8726773470ce686879ddd1dbff3b0df8cdd64a3a5b59a1961e9c5cbc6be7/ghoshell_container-0.3.1.tar.gz", hash = "sha256:ff2d17374e74867588226814ba197d50b61c7c391277c5005176923434a7e894", size = 16897, upload-time = "2026-02-03T15:05:23.669Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/94/1918758a93f79715dc72a573315949a9e9e66c368660c0bff02410a1aea7/ghoshell_container-0.3.1-py3-none-any.whl", hash = "sha256:baf0d497fcc217e454615c7a3e438bc05c6cfa5167bbc22c1fda90cc5ad1af65", size = 13036, upload-time = "2026-02-03T15:05:22.604Z" },
+]
+
+[[package]]
+name = "ghoshell-moss"
+version = "0.1.0b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "ghoshell-common" },
+    { name = "ghoshell-container" },
+    { name = "janus" },
+    { name = "jsonargparse" },
+    { name = "numpy" },
+    { name = "orjson" },
+    { name = "pillow" },
+    { name = "python-dateutil" },
+    { name = "python-frontmatter" },
+    { name = "python-ulid" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/0f/cbfabfe9cf68f72e0271cf2a7f89fc11132ea5ad448bf6f70e1cad2205d9/ghoshell_moss-0.1.0b0.tar.gz", hash = "sha256:8e4ab55b0c6ead21f16e7e3d8026b27eae4a89976ff4bbca9df823d45503e9d6", size = 778493, upload-time = "2026-06-02T18:20:37.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/a0/4ddc91f3f440cf6335ade427bda97efc8af3ffd4176ea7cc3b5d4b7fe882/ghoshell_moss-0.1.0b0-py3-none-any.whl", hash = "sha256:c6fad2317ff9252e3939f42b431fe3ab789db9d63dcb4bb1f134a1faa89744d2", size = 853082, upload-time = "2026-06-02T18:20:35.046Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "janus"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/7f/69884b6618be4baf6ebcacc716ee8680a842428a19f403db6d1c0bb990aa/janus-2.0.0.tar.gz", hash = "sha256:0970f38e0e725400496c834a368a67ee551dc3b5ad0a257e132f5b46f2e77770", size = 22910, upload-time = "2024-12-13T12:59:08.622Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/34/65604740edcb20e1bda6a890348ed7d282e7dd23aa00401cbe36fd0edbd9/janus-2.0.0-py3-none-any.whl", hash = "sha256:7e6449d34eab04cd016befbd7d8c0d8acaaaab67cb59e076a69149f9031745f9", size = 12161, upload-time = "2024-12-13T12:59:06.106Z" },
+]
+
+[[package]]
+name = "jsonargparse"
+version = "4.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/0b/f012466077d803b546955bf827ab30a320ad1550e3167195432cc2d6bfad/jsonargparse-4.49.0.tar.gz", hash = "sha256:9e691a09d937fb4c6bc1f6d3bf6c3546efa03381ea1e64ee10759095f1b14da7", size = 125237, upload-time = "2026-05-15T06:48:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/64/51cbc9044f5b1ee4fb9894fe791f50dfdb52dc080acfafb5818ba19e8c27/jsonargparse-4.49.0-py3-none-any.whl", hash = "sha256:2025880765fd792f6fb9861aa93f26da5f6c350be5d7656321369b22b0d2538e", size = 134834, upload-time = "2026-05-15T06:48:40.76Z" },
+]
+
+[[package]]
+name = "moss-waveform"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "ghoshell-moss" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "ghoshell-moss" }]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6d/11867a3ffa3a3608d84a4de51ef4dd0896d6b5cc9132fbe1daf593e677bc/orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9ef6fe90aadef185c7b128859f40beb24720b4ecea95379fc9000931179c3a49", size = 228515, upload-time = "2026-05-06T15:09:57.265Z" },
+    { url = "https://files.pythonhosted.org/packages/24/75/05912954c8b288f34fcf5cd4b9b071cb4f6e77b9961e175e56ebb258089f/orjson-3.11.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5c9b8f28e726e97d97696c826bc7bea5d71cecd63576dba92924a32c1961291", size = 128409, upload-time = "2026-05-06T15:09:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/1c3a47df3bc8191ea9ac51603bbb872a95167a364320c269f2557911f406/orjson-3.11.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a473dbb4162108b27901492546f83c76fdcea3d0eadff00ae7a07e18dcce09", size = 132106, upload-time = "2026-05-06T15:10:00.798Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/cf/b33b5f3e695ae7d63feef9d915c37cc3b8f465493dcd4f8e0b4c697a2366/orjson-3.11.9-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:011382e2a60fda9d46f1cdee31068cfc52ffe952b587d683ec0463002802a0f4", size = 127864, upload-time = "2026-05-06T15:10:02.15Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6a/6cf69385a58208024fcb8c014e2141b8ce838aba6492b589f8acfff97fab/orjson-3.11.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2d3dc759490128c5c1711a53eeaa8ee1d437fd0038ffd2b6008abf46db3f882", size = 135213, upload-time = "2026-05-06T15:10:03.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f8/0b1bd3e8f2efcdd376af5c8cfd79eaf13f018080c0089c80ebd724e3c7fb/orjson-3.11.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8ea516b3726d190e1b4297e6f4e7a8650347ae053868a18163b4dd3641d1fff", size = 145994, upload-time = "2026-05-06T15:10:05.083Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/59/dab79f61044c529d2c81aecdc589b1f833a1c8dec11ba3b1c2498a02ca7e/orjson-3.11.9-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:380cdce7ba24989af81d0a7013d0aaec5d0e2a21734c0e2681b1bc4f141957fe", size = 132744, upload-time = "2026-05-06T15:10:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4fa4f0af7fa18951f7ab3fc2148e223af211bf03f59e1c6034ec3f97f21d61", size = 134014, upload-time = "2026-05-06T15:10:08.213Z" },
+    { url = "https://files.pythonhosted.org/packages/50/c7/375e83a76851b73b2e39f3bcf0e5a19e2b89bad13e5bca97d0b293d27f24/orjson-3.11.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a8f5f8bc7ce7d59f08d9f99fa510c06496164a24cb5f3d34537dbd9ca30132e2", size = 141509, upload-time = "2026-05-06T15:10:09.595Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7c/49d5d82a3d3097f641f094f552131f1e2723b0b8cb0fa2874ab65ecfffa6/orjson-3.11.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4d7fde5501b944f83b3e665e1b31343ff6e154b15560a16b7130ea1e594a4206", size = 415127, upload-time = "2026-05-06T15:10:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/dc/7446c538590d55f455647e5f3c61fc33f7108714e7afcffa6a2a033f8350/orjson-3.11.9-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cde1a448023ba7d5bb4c01c5afb48894380b5e4956e0627266526587ef4e535f", size = 148025, upload-time = "2026-05-06T15:10:12.842Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e5/4d2d8af06f788329b4f78f8cc3679bb395392fcaa1e4d8d3c33e85308fa4/orjson-3.11.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e63adb0e1f1ed5d9e168f50a91ceb93ae6420731d222dc7da5c69409aa47aa", size = 136943, upload-time = "2026-05-06T15:10:14.405Z" },
+    { url = "https://files.pythonhosted.org/packages/06/69/850264ccf6d80f6b174620d30a87f65c9b1490aba33fe6b62798e618cad3/orjson-3.11.9-cp312-cp312-win32.whl", hash = "sha256:2d057a602cdd19a0ad680417527c45b6961a095081c0f46fe0e03e304aac6470", size = 131606, upload-time = "2026-05-06T15:10:15.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/973a43fc9c55e20f2051e9830997649f669be0cb3ca52192087c0143f118/orjson-3.11.9-cp312-cp312-win_amd64.whl", hash = "sha256:59e403b1cc5a676da8eaf31f6254801b7341b3e29efa85f92b48d272637e77be", size = 127101, upload-time = "2026-05-06T15:10:17.129Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/495470f0e4a18f73fa10b7f6b84b464ec4cc5291c4e0c7c2a6c400bef006/orjson-3.11.9-cp312-cp312-win_arm64.whl", hash = "sha256:9af678d6488357948f1f84c6cd1c1d397c014e1ae2f98ae082a44eb48f602624", size = 126736, upload-time = "2026-05-06T15:10:18.645Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/93fcc25907235c344ae73122f8a4e01d2d393ef062b4af7d2e2487a32c37/orjson-3.11.9-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:4bab1b2d6141fe7b32ae71dac905666ece4f94936efbfb13d55bb7739a3a6021", size = 228458, upload-time = "2026-05-06T15:10:20.079Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/27/b1e6dadb3c080313c03fdd8067b85e6a0460c7d8d6a1c3984ef77b904e4d/orjson-3.11.9-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:844417969855fc7a41be124aafe83dc424592a7f77cd4501900c67307122b92c", size = 128368, upload-time = "2026-05-06T15:10:21.549Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0f/c9ede0bf052f6b4051e64a7d4fa91b725cccf8321a6a786e86eb03519f00/orjson-3.11.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffe02797b5e9f3a9d8292ddcd289b474ad13e81ad83cd1891a240811f1d2cb81", size = 132070, upload-time = "2026-05-06T15:10:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/26/d398e28048dc18205bbe812f2c88cb9b40313db2470778e25964796458fe/orjson-3.11.9-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e4eed3b200023042814d2fc8a5d2e880f13b52e1ed2485e83da4f3962f7dc1a", size = 127892, upload-time = "2026-05-06T15:10:24.714Z" },
+    { url = "https://files.pythonhosted.org/packages/66/60/52b0054c4c700d5aa7fc5b7ca96917400d8f061307778578e67a10e25852/orjson-3.11.9-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aff7da9952a5ad1cef8e68017724d96c7b9a66e99e91d6252e1b133d67a7b10", size = 135217, upload-time = "2026-05-06T15:10:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/97/1e3dc2b2a28b7b2528f403d2fc1d79ec5f39af3bc143ab65d3ec26426385/orjson-3.11.9-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d4e98d6f3b8afed8bc8cd9718ec0cdf46661826beefb53fe8eafb37f2bf0362", size = 145980, upload-time = "2026-05-06T15:10:28.062Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/39/31fbfe7850f2de32dee7e7e5c09f26d403ab01e440ac96001c6b01ad3c99/orjson-3.11.9-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a81d52442a7c99b3662333235b3adf96a1715864658b35bb797212be7bddb97", size = 132738, upload-time = "2026-05-06T15:10:29.727Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/08/dca0082dd2a194acb93e5457e73455388e2e2ca464a2672449a9ddbb679d/orjson-3.11.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e39364e726a8fff737309aff059ff67d8a8c8d5b677be7bb49a8b3e84b7e218", size = 134033, upload-time = "2026-05-06T15:10:31.152Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d4/5bdb0626801230139987385554c5d4c42255218ac906525bf4347f22cd95/orjson-3.11.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4fd66214623f1b17501df9f0543bef0b833979ab5b6ded1e1d123222866aa8c9", size = 141492, upload-time = "2026-05-06T15:10:32.641Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/88/a21fb53b3ede6703aede6dce4710ed4111e5b201cfa6bbff5e544f9d47d7/orjson-3.11.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8ecc30f10465fa1e0ce13fd01d9e22c316e5053a719a8d915d4545a09a5ff677", size = 415087, upload-time = "2026-05-06T15:10:34.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/57/1b30daf70f0d8180e9a73cefbfbdd99e4bf19eb020466502b01fba7e0e50/orjson-3.11.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:97db4c94a7db398a5bd636273324f0b3fd58b350bbbac8bb380ceb825a9b40f4", size = 148031, upload-time = "2026-05-06T15:10:36.358Z" },
+    { url = "https://files.pythonhosted.org/packages/04/83/45fbb6d962e260807f99441db9613cee868ceda4baceda59b3720a563f97/orjson-3.11.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f78cf8fec5bd627f4082b8dfeac7871b43d7f3274904492a43dab39f18a19a0", size = 136915, upload-time = "2026-05-06T15:10:38.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/cc/2d10025f9056d376e4127ec05a5808b218d46f035fdc08178a5411b34250/orjson-3.11.9-cp313-cp313-win32.whl", hash = "sha256:d4087e5c0209a0a8efe4de3303c234b9c44d1174161dcd851e8eea07c7560b32", size = 131613, upload-time = "2026-05-06T15:10:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bd/2775ff28bfe883b9aa1ff348300542eb2ef1ee18d8ae0e3a49846817a865/orjson-3.11.9-cp313-cp313-win_amd64.whl", hash = "sha256:051b102c93b4f634e89f3866b07b9a9a98915ada541f4ec30f177067b2694979", size = 127086, upload-time = "2026-05-06T15:10:41.262Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/d26799e580939e32a7da9a39531bc9e58e15ca32ffaa6a8cb3e9bb0d22cd/orjson-3.11.9-cp313-cp313-win_arm64.whl", hash = "sha256:cce9127885941bd28f080cecf1f1d288336b7e0d812c345b08be88b572796254", size = 126696, upload-time = "2026-05-06T15:10:42.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/eb/5da01e356015aee6ecfa1187ced87aef51364e306f5e695dd52719bf0e78/orjson-3.11.9-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:b6ef1979adc4bc243523f1a2ba91418030a8e29b0a99cbe7e0e2d6807d4dce6e", size = 228465, upload-time = "2026-05-06T15:10:44.097Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/3e0e0c14c957133bcd855395c62b55ed4e3b0af23ffea11b032cb1dcbdb1/orjson-3.11.9-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:f36b7f32c7c0db4a719f1fc5824db4a9c6f8bd1a354debb91faf26ebf3a4c71e", size = 128364, upload-time = "2026-05-06T15:10:45.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5a/07d8aa117211a8ed7630bda80c8c0b14d04e0f8dcf99bcf49656e4a710eb/orjson-3.11.9-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08f4d8ebb44925c794e535b2bebc507cebf32209df81de22ae285fb0d8d66de0", size = 132063, upload-time = "2026-05-06T15:10:47.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ec/4acaf21483e18aa945be74a474c74b434f284b549f275a0a39b9f98956e9/orjson-3.11.9-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6cc7923789694fd58f001cbcac7e47abc13af4d560ebbfcf3b41a8b1a0748124", size = 122356, upload-time = "2026-05-06T15:10:48.765Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d8/5f0555e7638801323b7a75850f92e7dfa891bc84fe27a1ba4449170d1200/orjson-3.11.9-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea5c46eb2d3af39e806b986f4b09d5c2706a1f5afde3cbf7544ce6616127173c", size = 129592, upload-time = "2026-05-06T15:10:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/30/ed9860412a3603ceb3c5955bfd72d28b9d0e7ba6ed81add14f83d7114236/orjson-3.11.9-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5d89a2ed90731df3be64bab0aa44f78bff39fdc9d71c291f4a8023aa46425b7", size = 140491, upload-time = "2026-05-06T15:10:51.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/17/adc514dea7ac7c505527febf884934b815d34f0c7b8693c1a8b39c5c4a57/orjson-3.11.9-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:25e4aed0312d292c09f61af25bba34e0b2c88546041472b09088c39a4d828af1", size = 127309, upload-time = "2026-05-06T15:10:53.329Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3e/c0b690253f0b82d86e99949af13533363acfb5432ecb5d53dd5b3bce9c34/orjson-3.11.9-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aaea64f3f467d22e70eeed68bdccb3bc4f83f650446c4a03c59f2cba28a108db", size = 134030, upload-time = "2026-05-06T15:10:54.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/7a/bc82a0bb25e9faaf92dc4d9ef002732efc09737706af83e346788641d4a7/orjson-3.11.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a028425d1b440c5d92a6be1e1a020739dfe67ea87d96c6dbe828c1b30041728b", size = 141482, upload-time = "2026-05-06T15:10:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/01/55/e69188b939f77d5d32a9833745ace31ea5ccae3ab613a1ec185d3cd2c4fb/orjson-3.11.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5b192c6cf397e4455b11523c5cf2b18ed084c1bbd61b6c0926344d2129481972", size = 415178, upload-time = "2026-05-06T15:10:58.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/b8a5a7ac527e80b9cb11d51e3f6689b709279183264b9ec5c7bc680bb8b5/orjson-3.11.9-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea407d4ccf5891d667d045fecae97a7a1e5e87b3b97f97ae1803c2e741130be0", size = 148089, upload-time = "2026-05-06T15:11:00.441Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4e/00503f64204bf859b37213a63927028f30fb6268cd8677fb0a5ad48155e1/orjson-3.11.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f63aaf97afd9f6dec5b1a68e1b8da12bfccb4cb9a9a65c3e0b6c847849e7586", size = 136921, upload-time = "2026-05-06T15:11:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ba/a23b82a0a8d0ed7bed4e5f5035aae751cad4ff6a1e8d2ecd14d8860f5929/orjson-3.11.9-cp314-cp314-win32.whl", hash = "sha256:e30ab17845bb9fa54ccf67fa4f9f5282652d54faa6d17452f47d0f369d038673", size = 131638, upload-time = "2026-05-06T15:11:03.696Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/0c6798456bade745c75c452342dabacce5798196483e77e643be1f53877d/orjson-3.11.9-cp314-cp314-win_amd64.whl", hash = "sha256:32ef5f4283a3be81913947d19608eacb7c6608026851123790cd9cc8982af34b", size = 127078, upload-time = "2026-05-06T15:11:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/16/21/5a3f1e8913103b703a436a5664238e5b965ec392b555fe68943ea3691e6b/orjson-3.11.9-cp314-cp314-win_arm64.whl", hash = "sha256:eebdbdeef0094e4f5aefa20dcd4eb2368ab5e7a3b4edea27f1e7b2892e009cf9", size = 126687, upload-time = "2026-05-06T15:11:06.602Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-frontmatter"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e8/79cbe69864d44f3b48e70ebee0a872a7d5a4e7150c9f8577ed7a5beefff0/python_frontmatter-1.3.0.tar.gz", hash = "sha256:acc73e477a568dc2a25c9e130c6c68ae8daa8c204c8f7e813db47d6a7280dcf2", size = 8322, upload-time = "2026-05-20T19:21:44.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a3/17c284b4f4d8ad50f0f9ba70ad8fcc35c777aeafcdbbffdd91bbdc5ab379/python_frontmatter-1.3.0-py3-none-any.whl", hash = "sha256:9f7dd9260bec99044219159a329f64f039087f9d1a2124c9442556f2fe6f82ec", size = 10562, upload-time = "2026-05-20T19:21:43.323Z" },
+]
+
+[[package]]
+name = "python-ulid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/7e/0d6c82b5ccc71e7c833aed43d9e8468e1f2ff0be1b3f657a6fcafbb8433d/python_ulid-3.1.0.tar.gz", hash = "sha256:ff0410a598bc5f6b01b602851a3296ede6f91389f913a5d5f8c496003836f636", size = 93175, upload-time = "2025-08-18T16:09:26.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/a0/4ed6632b70a52de845df056654162acdebaf97c20e3212c559ac43e7216e/python_ulid-3.1.0-py3-none-any.whl", hash = "sha256:e2cdc979c8c877029b4b7a38a6fba3bc4578e4f109a308419ff4d3ccf0a46619", size = 11577, upload-time = "2025-08-18T16:09:25.047Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]

--- a/.moss_ws/configs/audio_capture.yml
+++ b/.moss_ws/configs/audio_capture.yml
@@ -1,0 +1,6 @@
+# dump from `ghoshell_moss.contracts.audio:AudioCaptureConfig` 
+sample_rate: 44100
+channels: 1
+format: pcm_s16le
+frame_duration_ms: 50
+device_pattern: blackhole

--- a/.moss_ws/src/MOSS/manifests/configs.py
+++ b/.moss_ws/src/MOSS/manifests/configs.py
@@ -19,7 +19,10 @@
 
 from ghoshell_moss.host.providers.audio_player_provider import AudioPlayerConfig
 from ghoshell_moss.host.providers.tts_service_provider import TTSManagerConfig
+from ghoshell_moss.contracts.audio import AudioCaptureConfig
 
 tts_config = TTSManagerConfig()
 
 audio_player_config = AudioPlayerConfig()
+
+audio_capture_config = AudioCaptureConfig()

--- a/.moss_ws/src/MOSS/manifests/providers.py
+++ b/.moss_ws/src/MOSS/manifests/providers.py
@@ -17,6 +17,7 @@ from ghoshell_moss.host.providers import (
 from ghoshell_moss.host.providers.tts_service_provider import TTSServiceProvider
 from ghoshell_moss.host.providers.speech_service_provider import TTSSpeechServiceProvider
 from ghoshell_moss.host.providers.audio_player_provider import AudioPlayerProvider
+from ghoshell_moss.host.providers.audio_capture_provider import AudioCaptureProvider
 from ghoshell_moss.core.resources.memory_registry import InMemoryResourceRegistryProvider
 from ghoshell_moss.host.fractal.zenoh_fractal import ZenohFractalHubProvider, ZenohFractalCellContractProvider
 
@@ -33,6 +34,8 @@ topic_service_provider = ZenohTopicServiceProvider()
 # audio player and speech
 
 player_service_provider = AudioPlayerProvider()
+
+capture_source_provider = AudioCaptureProvider()
 
 tts_service_provider = TTSServiceProvider()
 

--- a/src/ghoshell_moss/contracts/audio.py
+++ b/src/ghoshell_moss/contracts/audio.py
@@ -1,0 +1,110 @@
+"""
+Audio capture contracts — shared abstractions for system audio input.
+
+Capture source → raw PCM → Zenoh stream → consumers (ASR, waveform, AI perception).
+"""
+from abc import ABC, abstractmethod
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from ghoshell_moss.contracts.configs import ConfigType
+
+__all__ = [
+    "AudioFrameMeta",
+    "AudioChunk",
+    "AudioCaptureConfig",
+    "AudioRuntimeInfo",
+    "AudioCaptureSource",
+    "AudioPullLatest",
+    "AudioSequentialConsumer",
+]
+
+
+class AudioFrameMeta(BaseModel):
+    """Per-frame metadata computed once at capture, shared by all consumers."""
+
+    rms_db: float = 0.0
+    bands: dict[str, float] = Field(default_factory=lambda: {"bass": -96, "mid": -96, "high": -96})
+    is_silent: bool = True
+
+
+class AudioChunk(BaseModel):
+    """One frame of captured audio — raw PCM plus precomputed metadata."""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    seq: int = 0
+    timestamp: float = 0.0
+    samples: np.ndarray = Field(default_factory=lambda: np.array([], dtype=np.int16))
+    meta: AudioFrameMeta = Field(default_factory=AudioFrameMeta)
+
+
+class AudioCaptureConfig(ConfigType):
+    """Format consensus — consumers read this to know stream parameters."""
+
+    sample_rate: int = 44100
+    channels: int = 1
+    format: str = "pcm_s16le"
+    frame_duration_ms: int = 50
+    device_pattern: str = "blackhole"
+
+    @classmethod
+    def conf_name(cls) -> str:
+        return "audio_capture"
+
+
+class AudioRuntimeInfo(BaseModel):
+    """Runtime discovery — where the stream lives and whether it's alive."""
+
+    running: bool = False
+    stream_key: str = ""
+    device_name: str = ""
+    device_explain: str = ""
+    started_at: float = 0.0
+    last_heartbeat: float = 0.0
+
+
+class AudioCaptureSource(ABC):
+    """Singleton capture source. Owns the microphone, publishes PCM to Zenoh."""
+
+    @abstractmethod
+    async def start(self) -> None: ...
+
+    @abstractmethod
+    def device_explain(self) -> str: ...
+
+    @abstractmethod
+    def new_consumer(self, ring_buffer_frames: int = 64) -> "AudioPullLatest": ...
+
+    @abstractmethod
+    def new_sequential_consumer(self, max_queue_frames: int = 128) -> "AudioSequentialConsumer": ...
+
+    @abstractmethod
+    async def close(self) -> None: ...
+
+
+class AudioPullLatest(ABC):
+    """Non-blocking latest-frame consumer. For waveform display, AI perception."""
+
+    @abstractmethod
+    def pull_latest(self) -> AudioChunk | None: ...
+
+    @abstractmethod
+    def close(self) -> None: ...
+
+
+class AudioSequentialConsumer(ABC):
+    """Ordered, lossless consumer with backpressure. For ASR, audio recording."""
+
+    @abstractmethod
+    async def start(self) -> None: ...
+
+    @abstractmethod
+    async def close(self) -> None: ...
+
+    @abstractmethod
+    def __aiter__(self) -> "AudioSequentialConsumer": ...
+
+    @abstractmethod
+    async def __anext__(self) -> AudioChunk: ...

--- a/src/ghoshell_moss/host/impl.py
+++ b/src/ghoshell_moss/host/impl.py
@@ -81,6 +81,10 @@ class Host(MossHost):
             workspace=self._workspace,
         )
 
+        # Register AudioCaptureSource as lifecycle — auto start/stop with Matrix.
+        from ghoshell_moss.contracts.audio import AudioCaptureSource
+        self._matrix.register_lifecycle_objects(AudioCaptureSource)
+
     def name(self) -> str:
         return self._env.meta_config.name
 

--- a/src/ghoshell_moss/host/impl.py
+++ b/src/ghoshell_moss/host/impl.py
@@ -81,10 +81,6 @@ class Host(MossHost):
             workspace=self._workspace,
         )
 
-        # Register AudioCaptureSource as lifecycle — auto start/stop with Matrix.
-        from ghoshell_moss.contracts.audio import AudioCaptureSource
-        self._matrix.register_lifecycle_objects(AudioCaptureSource)
-
     def name(self) -> str:
         return self._env.meta_config.name
 

--- a/src/ghoshell_moss/host/matrix.py
+++ b/src/ghoshell_moss/host/matrix.py
@@ -672,7 +672,7 @@ class MatrixImpl(Matrix):
                             "%s bootstrap bound lifecycle object: %s",
                             self._log_prefix, lifecycle,
                         )
-                        await self._async_exit_stack.enter_async_context(lifecycle)
+                        await self._async_exit_stack.enter_async_context(lifecycle_obj)
             self._lifecycle_bound_objects_or_types = lifecycle_objects
             # 进入到根据约定可以做绑定的生命周期对象.
             for lifecycle_contract in self._lifecycle_level_contracts():

--- a/src/ghoshell_moss/host/providers/audio_capture_provider.py
+++ b/src/ghoshell_moss/host/providers/audio_capture_provider.py
@@ -1,0 +1,22 @@
+from ghoshell_moss.contracts.audio import AudioCaptureSource
+from ghoshell_moss.contracts.configs import ConfigStore
+from ghoshell_moss.contracts.logger import LoggerItf
+from ghoshell_container import IoCContainer, Provider
+from ghoshell_moss.host.speech.capture.miniaudio_capture import MiniAudioCaptureSource
+
+__all__ = ["AudioCaptureProvider"]
+
+
+class AudioCaptureProvider(Provider[AudioCaptureSource]):
+
+    def singleton(self) -> bool:
+        return True
+
+    def factory(self, con: IoCContainer) -> AudioCaptureSource:
+        from ghoshell_moss.contracts.audio import AudioCaptureConfig
+        from ghoshell_moss.core.blueprint.matrix import Matrix
+
+        matrix = con.force_fetch(Matrix)
+        store = con.force_fetch(ConfigStore)
+        config = store.get_or_create(AudioCaptureConfig())
+        return MiniAudioCaptureSource(matrix=matrix, config=config)

--- a/src/ghoshell_moss/host/speech/capture/__init__.py
+++ b/src/ghoshell_moss/host/speech/capture/__init__.py
@@ -1,0 +1,9 @@
+from .miniaudio_capture import (
+    MiniAudioCaptureSource,
+    MiniAudioSequentialConsumer,
+)
+
+__all__ = [
+    "MiniAudioCaptureSource",
+    "MiniAudioSequentialConsumer",
+]

--- a/src/ghoshell_moss/host/speech/capture/miniaudio_capture.py
+++ b/src/ghoshell_moss/host/speech/capture/miniaudio_capture.py
@@ -102,12 +102,15 @@ class MiniAudioCaptureSource(AudioCaptureSource):
         self._matrix = matrix
         self._config = config
         self._logger = matrix.logger or logging.getLogger("moss.audio_capture")
-        self._session = matrix.session
         self._capture: miniaudio.CaptureDevice | None = None
         self._locker: Lock | None = None
         self._seq = 0
         self._started = False
         self._closing = False
+
+    @property
+    def _session(self):
+        return self._matrix.session
 
     # ── lifecycle ──────────────────────────────────────────────
 

--- a/src/ghoshell_moss/host/speech/capture/miniaudio_capture.py
+++ b/src/ghoshell_moss/host/speech/capture/miniaudio_capture.py
@@ -1,0 +1,339 @@
+"""
+MiniAudio-based audio capture — system audio → raw PCM → Zenoh stream.
+"""
+import asyncio
+import collections
+import json
+import logging
+import struct
+import time
+from typing import Callable
+
+import miniaudio
+import numpy as np
+
+from ghoshell_moss.contracts.audio import (
+    AudioCaptureConfig,
+    AudioCaptureSource,
+    AudioChunk,
+    AudioFrameMeta,
+    AudioPullLatest,
+    AudioRuntimeInfo,
+    AudioSequentialConsumer,
+)
+from ghoshell_moss.contracts.workspace import Lock
+from ghoshell_moss.core.blueprint.matrix import Matrix
+from ghoshell_moss.core.blueprint.session import Sample
+
+__all__ = [
+    "MiniAudioCaptureSource",
+    "MiniAudioSequentialConsumer",
+    "unpack_chunk",
+    "pack_chunk",
+]
+
+_STREAM_KEY = "audio/pcm"
+_SILENCE_THRESHOLD_DB = -50.0
+
+
+def _compute_frame_meta(samples: np.ndarray) -> AudioFrameMeta:
+    """Compute RMS + 3-band energy + silence flag from raw PCM."""
+    f32 = samples.astype(np.float64) / 32768.0
+    rms = float(np.sqrt(np.mean(f32**2)))
+    rms_db = 20.0 * np.log10(max(rms, 1e-10))
+
+    fft = np.abs(np.fft.rfft(f32))
+    n = len(fft)
+    if n >= 6:
+        bass = 20.0 * np.log10(max(float(np.mean(fft[:n // 6])), 1e-10))
+        mid = 20.0 * np.log10(max(float(np.mean(fft[n // 6:2 * n // 3])), 1e-10))
+        high = 20.0 * np.log10(max(float(np.mean(fft[2 * n // 3:])), 1e-10))
+    else:
+        bass = mid = high = rms_db
+
+    return AudioFrameMeta(
+        rms_db=round(rms_db, 1),
+        bands={"bass": round(bass, 1), "mid": round(mid, 1), "high": round(high, 1)},
+        is_silent=rms_db < _SILENCE_THRESHOLD_DB,
+    )
+
+
+def pack_chunk(chunk: AudioChunk) -> bytes:
+    """Serialize AudioChunk to bytes for Zenoh transport.
+
+    Format: [4B meta_json_len(uint32 BE)] [meta_json(UTF-8)] [pcm(int16 LE)]
+    """
+    meta_json = json.dumps({
+        "seq": chunk.seq,
+        "timestamp": chunk.timestamp,
+        "rms_db": chunk.meta.rms_db,
+        "bands": chunk.meta.bands,
+        "is_silent": chunk.meta.is_silent,
+    }).encode("utf-8")
+    header = struct.pack(">I", len(meta_json))
+    pcm = chunk.samples.astype(np.int16).tobytes()
+    return header + meta_json + pcm
+
+
+def unpack_chunk(data: bytes) -> AudioChunk:
+    """Deserialize bytes back to AudioChunk."""
+    meta_len = struct.unpack(">I", data[:4])[0]
+    meta_json = data[4:4 + meta_len].decode("utf-8")
+    meta_dict = json.loads(meta_json)
+    pcm = np.frombuffer(data[4 + meta_len:], dtype=np.int16)
+
+    meta = AudioFrameMeta(
+        rms_db=meta_dict["rms_db"],
+        bands=meta_dict["bands"],
+        is_silent=meta_dict["is_silent"],
+    )
+    return AudioChunk(
+        seq=meta_dict["seq"],
+        timestamp=meta_dict["timestamp"],
+        samples=pcm,
+        meta=meta,
+    )
+
+
+class MiniAudioCaptureSource(AudioCaptureSource):
+    """Capture system audio via miniaudio CaptureDevice, publish PCM to Zenoh."""
+
+    def __init__(self, *, matrix: Matrix, config: AudioCaptureConfig):
+        self._matrix = matrix
+        self._config = config
+        self._logger = matrix.logger or logging.getLogger("moss.audio_capture")
+        self._session = matrix.session
+        self._capture: miniaudio.CaptureDevice | None = None
+        self._locker: Lock | None = None
+        self._seq = 0
+        self._started = False
+        self._closing = False
+
+    # ── lifecycle ──────────────────────────────────────────────
+
+    async def start(self) -> None:
+        if self._started:
+            return
+
+        # Process lock — prevent duplicate device open across processes
+        ws = self._matrix.workspace
+        self._locker = ws.lock("audio_capture")
+        if not self._locker.acquire(timeout=0):
+            self._logger.warning("Audio capture lock held by another process, skipping start")
+            self._started = True  # mark as started so lifecycle can proceed
+            return
+
+        # Device discovery
+        device_id = self._find_device()
+        if device_id is not None:
+            self._logger.info("Audio capture using device id=%s", device_id)
+        else:
+            self._logger.info("Audio capture using default input device")
+
+        # Build capture device
+        self._capture = miniaudio.CaptureDevice(
+            input_format=miniaudio.SampleFormat.SIGNED16,
+            nchannels=self._config.channels,
+            sample_rate=self._config.sample_rate,
+            buffersize_msec=self._config.frame_duration_ms,
+            device_id=device_id,
+        )
+
+        # Start capture via callback generator
+        gen = self._make_capture_generator()
+        next(gen)  # prime
+        self._capture.start(gen)
+
+        # Write runtime info to tmp_storage
+        self._write_runtime_info()
+        self._started = True
+        self._logger.info("Audio capture started (key=%s, device=%s)",
+                          _STREAM_KEY, self.device_explain())
+
+    def device_explain(self) -> str:
+        if self._capture is None:
+            return "not started"
+        return f"miniaudio capture, {self._config.sample_rate}Hz, " \
+               f"{self._config.channels}ch, {self._config.format}"
+
+    async def close(self) -> None:
+        if self._closing:
+            return
+        self._closing = True
+
+        if self._capture is not None:
+            self._capture.stop()
+            self._capture.close()
+            self._capture = None
+
+        if self._locker is not None:
+            self._locker.release()
+            self._locker = None
+        elif self._started:
+            self._logger.info("Audio capture close (no-op, lock was held by another process)")
+
+        self._started = False
+        self._logger.info("Audio capture closed")
+
+    # ── MatrixLifecycleObject ──────────────────────────────────
+
+    async def __aenter__(self) -> "MiniAudioCaptureSource":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
+
+    # ── consumer factories ─────────────────────────────────────
+
+    def new_consumer(self, ring_buffer_frames: int = 64) -> AudioPullLatest:
+        return _MiniAudioPullLatest(
+            session=self._session,
+            stream_key=_STREAM_KEY,
+            maxlen=ring_buffer_frames,
+            logger=self._logger,
+        )
+
+    def new_sequential_consumer(self, max_queue_frames: int = 128) -> AudioSequentialConsumer:
+        return MiniAudioSequentialConsumer(
+            session=self._session,
+            stream_key=_STREAM_KEY,
+            maxsize=max_queue_frames,
+            logger=self._logger,
+        )
+
+    # ── internals ──────────────────────────────────────────────
+
+    def _find_device(self):
+        """Match a capture device by config.device_pattern."""
+        pattern = self._config.device_pattern.lower()
+        try:
+            for d in miniaudio.Devices().capture:
+                if pattern in d.name.lower():
+                    return d.id
+        except Exception as e:
+            self._logger.warning("Device enumeration failed: %s, using default", e)
+        return None
+
+    def _make_capture_generator(self):
+        """Build the miniaudio callback generator.
+
+        miniaudio calls gen.send(raw_bytes) from its internal thread,
+        where raw_bytes is SIGNED16 PCM matching our sample rate + channels.
+        """
+        channels = self._config.channels
+        sample_rate = self._config.sample_rate
+        frame_duration_ms = self._config.frame_duration_ms
+        logger = self._logger
+        session = self._session
+        stream_key = _STREAM_KEY
+        seq_ref = [0]  # mutable ref for closure
+
+        def _capture_generator():
+            while True:
+                data = yield  # bytes from miniaudio
+                try:
+                    ts = time.time()
+                    samples = np.frombuffer(data, dtype=np.int16).reshape(-1, channels)
+                    meta = _compute_frame_meta(samples)
+                    seq = seq_ref[0]
+                    seq_ref[0] += 1
+
+                    chunk = AudioChunk(seq=seq, timestamp=ts, samples=samples, meta=meta)
+                    packed = pack_chunk(chunk)
+                    session.pub_stream_delta(stream_key, packed)
+                except Exception:
+                    logger.exception("Error in capture callback")
+
+        return _capture_generator()
+
+    def _write_runtime_info(self) -> None:
+        try:
+            devices = miniaudio.Devices()
+            device_name = "default"
+            for d in devices.capture:
+                if d.is_default:
+                    device_name = d.name
+                    break
+        except Exception:
+            device_name = "unknown"
+
+        info = AudioRuntimeInfo(
+            running=True,
+            stream_key=_STREAM_KEY,
+            device_name=device_name,
+            device_explain=self.device_explain(),
+            started_at=time.time(),
+            last_heartbeat=time.time(),
+        )
+        try:
+            storage = self._matrix.session.tmp_storage
+            storage.put("audio_runtime_info.json", info.model_dump_json().encode("utf-8"))
+        except Exception as e:
+            self._logger.warning("Failed to write audio runtime info: %s", e)
+
+
+class _MiniAudioPullLatest(AudioPullLatest):
+    """Ring-buffer consumer. Non-blocking, latest frame wins."""
+
+    def __init__(self, *, session, stream_key: str, maxlen: int, logger):
+        self._ring: collections.deque[AudioChunk] = collections.deque(maxlen=maxlen)
+        self._logger = logger
+        self._release: Callable[[], None] | None = None
+        self._closed = False
+
+        self._release = session.sub_stream(stream_key, self._on_sample)
+
+    def _on_sample(self, sample: Sample) -> None:
+        try:
+            chunk = unpack_chunk(sample.payload)
+            self._ring.append(chunk)
+        except Exception:
+            pass  # tolerate deserialize failures
+
+    def pull_latest(self) -> AudioChunk | None:
+        if self._closed or not self._ring:
+            return None
+        return self._ring[-1]
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._release is not None:
+            self._release()
+            self._release = None
+
+
+class MiniAudioSequentialConsumer(AudioSequentialConsumer):
+    """Ordered queue consumer with backpressure. For ASR, audio recording."""
+
+    def __init__(self, *, session, stream_key: str, maxsize: int, logger):
+        self._session = session
+        self._stream_key = stream_key
+        self._maxsize = maxsize
+        self._logger = logger
+        self._stream = None
+        self._started = False
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        self._stream = self._session.get_stream(self._stream_key, maxsize=self._maxsize)
+        await self._stream.__aenter__()
+        self._started = True
+
+    async def close(self) -> None:
+        if self._stream is not None:
+            await self._stream.__aexit__(None, None, None)
+            self._stream = None
+        self._started = False
+
+    def __aiter__(self) -> "MiniAudioSequentialConsumer":
+        if not self._started:
+            raise RuntimeError("Consumer not started — call start() first")
+        return self
+
+    async def __anext__(self) -> AudioChunk:
+        sample = await self._stream.__anext__()  # raises StopAsyncIteration on sentinel
+        return unpack_chunk(sample.payload)

--- a/src/ghoshell_moss/host/speech/capture/miniaudio_capture.py
+++ b/src/ghoshell_moss/host/speech/capture/miniaudio_capture.py
@@ -175,15 +175,6 @@ class MiniAudioCaptureSource(AudioCaptureSource):
         self._started = False
         self._logger.info("Audio capture closed")
 
-    # ── MatrixLifecycleObject ──────────────────────────────────
-
-    async def __aenter__(self) -> "MiniAudioCaptureSource":
-        await self.start()
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
-        await self.close()
-
     # ── consumer factories ─────────────────────────────────────
 
     def new_consumer(self, ring_buffer_frames: int = 64) -> AudioPullLatest:

--- a/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/configs.py
+++ b/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/configs.py
@@ -19,7 +19,10 @@
 
 from ghoshell_moss.host.providers.audio_player_provider import AudioPlayerConfig
 from ghoshell_moss.host.providers.tts_service_provider import TTSManagerConfig
+from ghoshell_moss.contracts.audio import AudioCaptureConfig
 
 tts_config = TTSManagerConfig()
 
 audio_player_config = AudioPlayerConfig()
+
+audio_capture_config = AudioCaptureConfig()

--- a/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/providers.py
+++ b/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/providers.py
@@ -17,6 +17,7 @@ from ghoshell_moss.host.providers import (
 from ghoshell_moss.host.providers.tts_service_provider import TTSServiceProvider
 from ghoshell_moss.host.providers.speech_service_provider import TTSSpeechServiceProvider
 from ghoshell_moss.host.providers.audio_player_provider import AudioPlayerProvider
+from ghoshell_moss.host.providers.audio_capture_provider import AudioCaptureProvider
 from ghoshell_moss.core.resources.memory_registry import InMemoryResourceRegistryProvider
 from ghoshell_moss.host.fractal.zenoh_fractal import ZenohFractalHubProvider, ZenohFractalCellContractProvider
 
@@ -33,6 +34,8 @@ topic_service_provider = ZenohTopicServiceProvider()
 # audio player and speech
 
 player_service_provider = AudioPlayerProvider()
+
+capture_source_provider = AudioCaptureProvider()
 
 tts_service_provider = TTSServiceProvider()
 

--- a/tests/ghoshell_moss/speech/test_miniaudio_capture.py
+++ b/tests/ghoshell_moss/speech/test_miniaudio_capture.py
@@ -1,133 +1,163 @@
+"""Contract tests for AudioCaptureSource and its consumers.
+
+Tests are written against the abstract interfaces and run against
+MiniAudioCaptureSource with a mocked Matrix — no Zenoh or hardware needed.
+"""
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 
-from ghoshell_moss.contracts.audio import AudioChunk, AudioFrameMeta
+from ghoshell_moss.contracts.audio import (
+    AudioCaptureConfig,
+    AudioCaptureSource,
+    AudioChunk,
+    AudioFrameMeta,
+    AudioPullLatest,
+    AudioSequentialConsumer,
+)
 from ghoshell_moss.host.speech.capture.miniaudio_capture import (
-    _compute_frame_meta,
+    MiniAudioCaptureSource,
     pack_chunk,
     unpack_chunk,
 )
 
 
-def _make_sine(duration: float, sample_rate: int, freq: float = 440.0, amplitude: float = 0.5) -> np.ndarray:
-    """Generate int16 sine wave, shape (n_samples, 1)."""
-    t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
-    wave = (np.sin(2 * np.pi * freq * t) * (32767 * amplitude)).astype(np.int16)
-    return wave.reshape(-1, 1)
+# ── helpers ──────────────────────────────────────────────────────────
+
+def _make_matrix():
+    """Minimal Matrix mock — session/workspace/logger stubs."""
+    m = MagicMock()
+    m.logger = MagicMock()
+    m.session = MagicMock()
+    m.workspace = MagicMock()
+    return m
 
 
-# ── _compute_frame_meta ────────────────────────────────────────────
+def _make_source(**config_kwargs) -> MiniAudioCaptureSource:
+    return MiniAudioCaptureSource(
+        matrix=_make_matrix(),
+        config=AudioCaptureConfig(**config_kwargs),
+    )
 
 
-class TestComputeFrameMeta:
-    def test_sine_dbfs_range(self):
-        """Full-scale sine: RMS ≈ -3 dBFS (amplitude 1.0 → peak at 0 dBFS)."""
-        samples = _make_sine(0.05, 44100, amplitude=1.0)  # full scale
-        meta = _compute_frame_meta(samples)
-        assert -6 < meta.rms_db <= 0
-        assert not meta.is_silent
-
-    def test_silence_is_detected(self):
-        """Zero samples → rms_db near -inf, is_silent=True."""
-        samples = np.zeros((2205, 1), dtype=np.int16)
-        meta = _compute_frame_meta(samples)
-        assert meta.rms_db < -50
-        assert meta.is_silent
-
-    def test_half_amplitude_lower_dbfs(self):
-        """Half amplitude → ~6 dB quieter than full scale."""
-        full = _make_sine(0.05, 44100, amplitude=1.0)
-        half = _make_sine(0.05, 44100, amplitude=0.5)
-        meta_full = _compute_frame_meta(full)
-        meta_half = _compute_frame_meta(half)
-        assert meta_half.rms_db < meta_full.rms_db
-
-    def test_bands_have_expected_keys(self):
-        """Meta bands always contain bass, mid, high."""
-        samples = _make_sine(0.05, 44100)
-        meta = _compute_frame_meta(samples)
-        assert set(meta.bands.keys()) == {"bass", "mid", "high"}
-        for v in meta.bands.values():
-            assert isinstance(v, float)
-
-    def test_short_input_uses_rms_for_bands(self):
-        """When FFT has <6 bins, bands fall back to rms_db."""
-        samples = np.array([[100], [200], [300]], dtype=np.int16)  # 3 samples → FFT 2 bins
-        meta = _compute_frame_meta(samples)
-        assert meta.bands["bass"] == meta.bands["mid"] == meta.bands["high"]
-
-    def test_mono_2d_shape(self):
-        """(n, 1) shape input works correctly."""
-        samples = _make_sine(0.05, 44100)
-        assert samples.ndim == 2 and samples.shape[1] == 1
-        meta = _compute_frame_meta(samples)  # should not raise
-        assert isinstance(meta, AudioFrameMeta)
+# ── AudioCaptureSource contract ──────────────────────────────────────
 
 
-# ── pack_chunk / unpack_chunk ───────────────────────────────────────
+class TestAudioCaptureSource:
+    """Contract: any AudioCaptureSource."""
+
+    def test_device_explain_before_start(self):
+        """start 前 device_explain 返回有意义字符串，不含 running 语义."""
+        source: AudioCaptureSource = _make_source()
+        explain = source.device_explain()
+        assert isinstance(explain, str)
+        assert len(explain) > 0
+
+    @pytest.mark.asyncio
+    async def test_double_close_is_idempotent(self):
+        """重复 close 不抛异常."""
+        source: AudioCaptureSource = _make_source()
+        await source.close()
+        await source.close()
+
+    def test_new_consumer_returns_pull_latest(self):
+        """waveform / AI 感知场景：获取非阻塞消费者."""
+        source: AudioCaptureSource = _make_source()
+        consumer = source.new_consumer(ring_buffer_frames=64)
+        assert isinstance(consumer, AudioPullLatest)
+        consumer.close()
+
+    def test_new_sequential_consumer_returns_correct_type(self):
+        """ASR / 录音场景：获取顺序消费者."""
+        source: AudioCaptureSource = _make_source()
+        consumer = source.new_sequential_consumer(max_queue_frames=128)
+        assert isinstance(consumer, AudioSequentialConsumer)
 
 
-class TestPackUnpack:
-    def test_roundtrip(self):
-        """pack → unpack preserves all fields."""
-        samples = _make_sine(0.05, 44100).flatten()
-        meta = AudioFrameMeta(rms_db=-12.3, bands={"bass": -20, "mid": -12, "high": -8}, is_silent=False)
-        chunk = AudioChunk(seq=42, timestamp=1234567890.123, samples=samples, meta=meta)
+# ── AudioPullLatest contract ─────────────────────────────────────────
+
+
+class TestAudioPullLatest:
+    """Contract: any AudioPullLatest."""
+
+    def test_pull_latest_non_blocking_returns_none_or_chunk(self):
+        """无数据时 pull_latest 非阻塞返回 None."""
+        source = _make_source()
+        consumer: AudioPullLatest = source.new_consumer(ring_buffer_frames=32)
+        result = consumer.pull_latest()
+        assert result is None or isinstance(result, AudioChunk)
+        consumer.close()
+
+    def test_close_idempotent(self):
+        """close 可重复调用."""
+        source = _make_source()
+        consumer: AudioPullLatest = source.new_consumer(ring_buffer_frames=32)
+        consumer.close()
+        consumer.close()
+
+
+# ── AudioSequentialConsumer contract ─────────────────────────────────
+
+
+class TestAudioSequentialConsumer:
+    """Contract: any AudioSequentialConsumer."""
+
+    def test_iteration_without_start_raises(self):
+        """未 start 就迭代应抛出 RuntimeError."""
+        source = _make_source()
+        consumer: AudioSequentialConsumer = source.new_sequential_consumer(max_queue_frames=32)
+        with pytest.raises(RuntimeError):
+            consumer.__aiter__()
+
+    @pytest.mark.asyncio
+    async def test_close_before_start_is_safe(self):
+        """未 start 就 close 不抛异常."""
+        source = _make_source()
+        consumer: AudioSequentialConsumer = source.new_sequential_consumer(max_queue_frames=32)
+        await consumer.close()
+
+
+# ── Serialization contract ───────────────────────────────────────────
+
+
+class TestAudioChunkSerialization:
+    """AudioChunk 跨进程链路：capture 端 pack，consumer 端 unpack。"""
+
+    def test_roundtrip_preserves_all_fields(self):
+        """pack → unpack 后所有字段不变。这是跨进程传输的契约."""
+        rng = np.random.RandomState(42)
+        samples = (rng.randn(2205) * 8000).astype(np.int16)
+
+        chunk = AudioChunk(
+            seq=42,
+            timestamp=1234567890.123,
+            samples=samples.copy(),
+            meta=AudioFrameMeta(
+                rms_db=-12.3,
+                bands={"bass": -20.1, "mid": -12.3, "high": -8.7},
+                is_silent=False,
+            ),
+        )
 
         packed = pack_chunk(chunk)
-        assert isinstance(packed, bytes)
-
         unpacked = unpack_chunk(packed)
+
         assert unpacked.seq == 42
         assert unpacked.timestamp == pytest.approx(1234567890.123)
         assert unpacked.meta.rms_db == -12.3
-        assert unpacked.meta.bands == {"bass": -20, "mid": -12, "high": -8}
+        assert unpacked.meta.bands == {"bass": -20.1, "mid": -12.3, "high": -8.7}
         assert unpacked.meta.is_silent is False
         assert np.array_equal(unpacked.samples, samples)
 
-    def test_binary_header_length(self):
-        """First 4 bytes are uint32 BE meta_json length."""
-        samples = _make_sine(0.05, 44100).flatten()
-        chunk = AudioChunk(seq=0, timestamp=0.0, samples=samples, meta=AudioFrameMeta())
-        packed = pack_chunk(chunk)
-
-        import struct
-        meta_len = struct.unpack(">I", packed[:4])[0]
-        assert meta_len > 0
-        assert meta_len < 1024  # meta JSON is small
-
-    def test_silent_chunk_roundtrip(self):
-        """Silent meta flag survives roundtrip."""
+    def test_silent_frame_roundtrip(self):
+        """静音帧的 is_silent 标志在往返中正确保持."""
         samples = np.zeros(100, dtype=np.int16)
-        meta = AudioFrameMeta(rms_db=-96, bands={"bass": -96, "mid": -96, "high": -96}, is_silent=True)
-        chunk = AudioChunk(seq=0, timestamp=0.0, samples=samples, meta=meta)
-
-        packed = pack_chunk(chunk)
-        unpacked = unpack_chunk(packed)
+        chunk = AudioChunk(
+            seq=0, timestamp=0.0, samples=samples,
+            meta=AudioFrameMeta(rms_db=-96, bands={"bass": -96, "mid": -96, "high": -96}, is_silent=True),
+        )
+        unpacked = unpack_chunk(pack_chunk(chunk))
         assert unpacked.meta.is_silent is True
         assert unpacked.meta.rms_db == -96
-
-    def test_pcm_bytes_match_int16_size(self):
-        """PCM payload size = n_samples * 2 (int16)."""
-        samples = _make_sine(0.05, 44100).flatten()
-        chunk = AudioChunk(seq=0, timestamp=0.0, samples=samples, meta=AudioFrameMeta())
-
-        packed = pack_chunk(chunk)
-
-        import struct
-        meta_len = struct.unpack(">I", packed[:4])[0]
-        pcm_bytes = packed[4 + meta_len:]
-        assert len(pcm_bytes) == len(samples) * 2
-
-    def test_high_frequency_energy_in_high_band(self):
-        """8 kHz tone → high band should dominate over bass."""
-        samples = _make_sine(0.05, 44100, freq=8000.0, amplitude=0.5)
-        meta = _compute_frame_meta(samples)
-        # High-frequency tone → high band energy > bass band energy
-        assert meta.bands["high"] > meta.bands["bass"]
-
-    def test_low_frequency_energy_in_bass_band(self):
-        """100 Hz tone → bass band should dominate over high."""
-        samples = _make_sine(0.05, 44100, freq=100.0, amplitude=0.5)
-        meta = _compute_frame_meta(samples)
-        assert meta.bands["bass"] > meta.bands["high"]
+        assert np.array_equal(unpacked.samples, samples)

--- a/tests/ghoshell_moss/speech/test_miniaudio_capture.py
+++ b/tests/ghoshell_moss/speech/test_miniaudio_capture.py
@@ -1,0 +1,133 @@
+import numpy as np
+import pytest
+
+from ghoshell_moss.contracts.audio import AudioChunk, AudioFrameMeta
+from ghoshell_moss.host.speech.capture.miniaudio_capture import (
+    _compute_frame_meta,
+    pack_chunk,
+    unpack_chunk,
+)
+
+
+def _make_sine(duration: float, sample_rate: int, freq: float = 440.0, amplitude: float = 0.5) -> np.ndarray:
+    """Generate int16 sine wave, shape (n_samples, 1)."""
+    t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+    wave = (np.sin(2 * np.pi * freq * t) * (32767 * amplitude)).astype(np.int16)
+    return wave.reshape(-1, 1)
+
+
+# ── _compute_frame_meta ────────────────────────────────────────────
+
+
+class TestComputeFrameMeta:
+    def test_sine_dbfs_range(self):
+        """Full-scale sine: RMS ≈ -3 dBFS (amplitude 1.0 → peak at 0 dBFS)."""
+        samples = _make_sine(0.05, 44100, amplitude=1.0)  # full scale
+        meta = _compute_frame_meta(samples)
+        assert -6 < meta.rms_db <= 0
+        assert not meta.is_silent
+
+    def test_silence_is_detected(self):
+        """Zero samples → rms_db near -inf, is_silent=True."""
+        samples = np.zeros((2205, 1), dtype=np.int16)
+        meta = _compute_frame_meta(samples)
+        assert meta.rms_db < -50
+        assert meta.is_silent
+
+    def test_half_amplitude_lower_dbfs(self):
+        """Half amplitude → ~6 dB quieter than full scale."""
+        full = _make_sine(0.05, 44100, amplitude=1.0)
+        half = _make_sine(0.05, 44100, amplitude=0.5)
+        meta_full = _compute_frame_meta(full)
+        meta_half = _compute_frame_meta(half)
+        assert meta_half.rms_db < meta_full.rms_db
+
+    def test_bands_have_expected_keys(self):
+        """Meta bands always contain bass, mid, high."""
+        samples = _make_sine(0.05, 44100)
+        meta = _compute_frame_meta(samples)
+        assert set(meta.bands.keys()) == {"bass", "mid", "high"}
+        for v in meta.bands.values():
+            assert isinstance(v, float)
+
+    def test_short_input_uses_rms_for_bands(self):
+        """When FFT has <6 bins, bands fall back to rms_db."""
+        samples = np.array([[100], [200], [300]], dtype=np.int16)  # 3 samples → FFT 2 bins
+        meta = _compute_frame_meta(samples)
+        assert meta.bands["bass"] == meta.bands["mid"] == meta.bands["high"]
+
+    def test_mono_2d_shape(self):
+        """(n, 1) shape input works correctly."""
+        samples = _make_sine(0.05, 44100)
+        assert samples.ndim == 2 and samples.shape[1] == 1
+        meta = _compute_frame_meta(samples)  # should not raise
+        assert isinstance(meta, AudioFrameMeta)
+
+
+# ── pack_chunk / unpack_chunk ───────────────────────────────────────
+
+
+class TestPackUnpack:
+    def test_roundtrip(self):
+        """pack → unpack preserves all fields."""
+        samples = _make_sine(0.05, 44100).flatten()
+        meta = AudioFrameMeta(rms_db=-12.3, bands={"bass": -20, "mid": -12, "high": -8}, is_silent=False)
+        chunk = AudioChunk(seq=42, timestamp=1234567890.123, samples=samples, meta=meta)
+
+        packed = pack_chunk(chunk)
+        assert isinstance(packed, bytes)
+
+        unpacked = unpack_chunk(packed)
+        assert unpacked.seq == 42
+        assert unpacked.timestamp == pytest.approx(1234567890.123)
+        assert unpacked.meta.rms_db == -12.3
+        assert unpacked.meta.bands == {"bass": -20, "mid": -12, "high": -8}
+        assert unpacked.meta.is_silent is False
+        assert np.array_equal(unpacked.samples, samples)
+
+    def test_binary_header_length(self):
+        """First 4 bytes are uint32 BE meta_json length."""
+        samples = _make_sine(0.05, 44100).flatten()
+        chunk = AudioChunk(seq=0, timestamp=0.0, samples=samples, meta=AudioFrameMeta())
+        packed = pack_chunk(chunk)
+
+        import struct
+        meta_len = struct.unpack(">I", packed[:4])[0]
+        assert meta_len > 0
+        assert meta_len < 1024  # meta JSON is small
+
+    def test_silent_chunk_roundtrip(self):
+        """Silent meta flag survives roundtrip."""
+        samples = np.zeros(100, dtype=np.int16)
+        meta = AudioFrameMeta(rms_db=-96, bands={"bass": -96, "mid": -96, "high": -96}, is_silent=True)
+        chunk = AudioChunk(seq=0, timestamp=0.0, samples=samples, meta=meta)
+
+        packed = pack_chunk(chunk)
+        unpacked = unpack_chunk(packed)
+        assert unpacked.meta.is_silent is True
+        assert unpacked.meta.rms_db == -96
+
+    def test_pcm_bytes_match_int16_size(self):
+        """PCM payload size = n_samples * 2 (int16)."""
+        samples = _make_sine(0.05, 44100).flatten()
+        chunk = AudioChunk(seq=0, timestamp=0.0, samples=samples, meta=AudioFrameMeta())
+
+        packed = pack_chunk(chunk)
+
+        import struct
+        meta_len = struct.unpack(">I", packed[:4])[0]
+        pcm_bytes = packed[4 + meta_len:]
+        assert len(pcm_bytes) == len(samples) * 2
+
+    def test_high_frequency_energy_in_high_band(self):
+        """8 kHz tone → high band should dominate over bass."""
+        samples = _make_sine(0.05, 44100, freq=8000.0, amplitude=0.5)
+        meta = _compute_frame_meta(samples)
+        # High-frequency tone → high band energy > bass band energy
+        assert meta.bands["high"] > meta.bands["bass"]
+
+    def test_low_frequency_energy_in_bass_band(self):
+        """100 Hz tone → bass band should dominate over high."""
+        samples = _make_sine(0.05, 44100, freq=100.0, amplitude=0.5)
+        meta = _compute_frame_meta(samples)
+        assert meta.bands["bass"] > meta.bands["high"]


### PR DESCRIPTION
  Ghost 补上耳朵——系统音频感知链路：miniaudio CaptureDevice → 原始 PCM → Zenoh stream → 消费者各自加工。                                                                                        
   
  ### 新增                                                                                                                                                                                      
                                                                                                                                                                                              
  - **Contracts** (`contracts/audio.py`): 7 个符号 — `AudioFrameMeta`, `AudioChunk`, `AudioCaptureConfig`, `AudioRuntimeInfo`, `AudioCaptureSource`, `AudioPullLatest`,                         
  `AudioSequentialConsumer`                                                                                                                                                                   
  - **核心实现** (`host/speech/capture/miniaudio_capture.py`): `MiniAudioCaptureSource` — miniaudio callback generator 模式，FFT 在回调线程计算，`pack_chunk`/`unpack_chunk`                    
  二进制序列化，`_MiniAudioPullLatest` (ring buffer) + `MiniAudioSequentialConsumer` (async for + 背压) 两类消费者                                                                              
  - **Provider** (`host/providers/audio_capture_provider.py`): singleton，IoC 注入 Matrix + ConfigStore
  - **MatrixLifecycleObject 集成** (`host/impl.py`): `Host.__init__` 注册 `AudioCaptureSource`，Matrix 启动自动 `start()`，关闭自动 `close()`                                                   
  - **Waveform App** (`.moss_ws/apps/sensors/waveform/`): 跨进程可视化消费者，40 字符宽 bar + 部分块字符，bass/mid/high/rms 四行终端渲染                                                        
                                                                                                                                                                                                
  ### 修复                                                                                                                                                                                      
                                                                                                                                                                                                
  - `host/matrix.py`: 生命周期对象注册时 `lifecycle`(类型) → `lifecycle_obj`(实例)，修复 ABC 类调 `enter_async_context` 的 TypeError                                                            
  - `_compute_frame_meta`: int16 样本归一化 `/32768.0`，dB 转为标准 dBFS                                                                                                                      
  - Stub 同步: workspace manifests stubs 补充 audio capture 注册项                                                                                                                              
                                                                                                                                                                                                
  ### 架构                                                                                                                                                                                      
                                                                                                                                                                                                
  MiniAudioCaptureSource (singleton, MatrixLifecycle)                                                                                                                                           
    └─ start(): FileLocker → CaptureDevice(gen) → callback: FFT → pack → Zenoh pub_stream_delta("audio/pcm")                                                                                  
         ├─ _MiniAudioPullLatest (ring buffer, 非阻塞)                                                                                                                                          
         └─ MiniAudioSequentialConsumer (Queue, async for, 背压)                                                                                                                                
                                                                                                                                                                                                
  ### Test plan                                                                                                                                                                                 
                                                                                                                                                                                                
  - [x] `moss apps test sensors/waveform` — 波形终端渲染正常，bar 随音量波动                                                                                                                    
  - [ ] 进程锁容错 — 主进程持有 capture 锁时，App 进程 skip start 不抛异常                                                                                                                      
  - [ ] `moss workspace init` 新 workspace 包含 audio capture manifests  