### PR TITLE
fix: resolve 6 MCP Hub Channel issues — default scope, config registr…

### DIFF
--- a/.ai_partners/features/workstreams/2026/06/mcp-hub-channel/FEATURE.md
+++ b/.ai_partners/features/workstreams/2026/06/mcp-hub-channel/FEATURE.md
@@ -4,8 +4,8 @@ depends: [storage-typed-protocols]
 description: MCP Hub — 将 MCP 协议降级为纯 transport，CTML 接管调度，模型以原生 CTML 思路操作外部工具。
 milestone: null
 priority: P0
-status: in-progress
-status_note: 2026-06-07 全链路验证通过。6 issues 待修，见 Issues 节。
+status: completed
+status_note: 2026-06-07 全链路验证通过 + 6 issues 修复 + moss-repl 最终验收通过。
 title: MCP Hub Channel
 updated: '2026-06-07'
 ---
@@ -107,7 +107,7 @@ MCP server 的 tool 目录在 context messages 中展示（类似 skills 列表�
 
 以下 4 个问题在 2026-06-07 验证过程中发现，实现已完成但存在摩擦点。
 
-### Issue 1: 默认 scope 反了 — 应默认走 ConfigStore
+### Issue 1: 默认 scope 反了 — 应默认走 ConfigStore ✅ 已修
 
 **位置**: `src/ghoshell_moss/channels/mcp_hub.py:436`
 
@@ -123,7 +123,7 @@ self._scopes = scopes or []
 
 **修复**: 改默认值为 `[]`（空列表 → falsy → 不进入 scoped 分支 → `_load_config` 走 ConfigStore）。
 
-### Issue 2: MCPHubConfig 没有注册到 manifests/configs.py
+### Issue 2: MCPHubConfig 没有注册到 manifests/configs.py ✅ 已修
 
 **位置**: `.moss_ws/src/MOSS/manifests/configs.py`
 
@@ -134,7 +134,7 @@ self._scopes = scopes or []
 from ghoshell_moss.channels.mcp_hub import MCPHubConfig
 ```
 
-### Issue 3: add_server 不支持运行时传参
+### Issue 3: add_server 不支持运行时传参 ✅ 已修
 
 **位置**: `src/ghoshell_moss/channels/mcp_hub.py` — `MCPHubState._bootstrap()` 闭包中的 `add_server`
 
@@ -144,7 +144,7 @@ from ghoshell_moss.channels.mcp_hub import MCPHubConfig
 
 **前置依赖**: Issue 4（get_or_create）必须先修——否则首次添加时没有 config 对象可 append。
 
-### Issue 4: _load_config 缺少 get_or_create 语义
+### Issue 4: _load_config 缺少 get_or_create 语义 ✅ 已修
 
 **位置**: `src/ghoshell_moss/channels/mcp_hub.py:363-373`
 
@@ -185,7 +185,7 @@ def _load_config(self) -> MCPHubConfig | None:
 5. Issue 6 (删掉手写 instruction) — 框架已自动反射
 6. Issue 7 (补 JSON Schema) — context messages 缺失 tool 参数定义
 
-### Issue 6: _DEFAULT_INSTRUCTION 手写且冗余
+### Issue 6: _DEFAULT_INSTRUCTION 手写且冗余 ✅ 已修
 
 **位置**: `src/ghoshell_moss/channels/mcp_hub.py:201-212`
 
@@ -208,7 +208,7 @@ MCP Hub — 通过 MCP 协议接入的外部工具集。
 
 **修复**: 删除 `_DEFAULT_INSTRUCTION` 和 `get_instruction()` 覆写，让框架默认行为接管。
 
-### Issue 7: context messages 缺少 tool inputSchema
+### Issue 7: context messages 缺少 tool inputSchema ✅ 已修
 
 **位置**: `src/ghoshell_moss/channels/mcp_hub.py:401-418` — `get_context_messages`
 

--- a/.moss_ws/src/MOSS/manifests/configs.py
+++ b/.moss_ws/src/MOSS/manifests/configs.py
@@ -18,6 +18,7 @@
 
 from ghoshell_moss.host.providers.audio_player_provider import AudioPlayerConfig
 from ghoshell_moss.host.providers.tts_service_provider import TTSManagerConfig
+from ghoshell_moss.channels.mcp_hub import MCPHubConfig
 from ghoshell_moss.contracts.audio import AudioCaptureConfig
 
 tts_config = TTSManagerConfig()

--- a/src/ghoshell_moss/channels/mcp_hub.py
+++ b/src/ghoshell_moss/channels/mcp_hub.py
@@ -194,23 +194,29 @@ def _mcp_result_to_observe(
     return Observe(messages=messages)
 
 
+def _render_input_schema(schema: dict) -> str:
+    """将 MCP tool inputSchema 渲染为简洁的参数列表。"""
+    if not schema or schema.get('type') != 'object':
+        return ''
+    properties = schema.get('properties', {})
+    if not properties:
+        return ''
+    required = set(schema.get('required', []))
+    parts = []
+    for param_name, param_schema in properties.items():
+        ptype = param_schema.get('type', 'any')
+        pdesc = (param_schema.get('description', '') or '').split('\n')[0][:80]
+        req = ', required' if param_name in required else ''
+        if pdesc:
+            parts.append(f"`{param_name}` ({ptype}{req}): {pdesc}")
+        else:
+            parts.append(f"`{param_name}` ({ptype}{req})")
+    return ', '.join(parts)
+
+
 # ---------------------------------------------------------------------------
 # MCP Hub State
 # ---------------------------------------------------------------------------
-
-_DEFAULT_INSTRUCTION = """\
-MCP Hub — 通过 MCP 协议接入的外部工具集。
-
-使用方式:
-- 非阻塞调用 (推荐): <mcp:exec server="<name>" tool="<tool>" timeout="30.0">json args</mcp:exec>
-  结果在下一关键帧以 Observe 形式观察。
-- 阻塞调用 (仅当后续命令依赖返回值时): <mcp:exec_blocking server="<name>" tool="<tool>">json args</mcp:exec_blocking>
-  等待完成后才执行同通道后续命令。
-
-管理命令:
-- list_servers: 查看所有 server 连接状态
-- restart_server(name): 重启指定 server"""
-
 
 class MCPHubState(ChannelState):
     """管理 N 个 MCP client session 的 ChannelState。"""
@@ -226,7 +232,7 @@ class MCPHubState(ChannelState):
         self._matrix = matrix
         self._name = name
         self._description = description or 'MCP Hub — 管理外部 MCP 工具调用'
-        self._scopes = scopes or ['ghost', 'mode']
+        self._scopes = scopes or []
         self._uid = unique_id()
         self._sessions: dict[str, _MCPServerSession] = {}
         self._own_commands: dict[str, Command] = {}
@@ -281,22 +287,56 @@ class MCPHubState(ChannelState):
                 lines.append("No servers configured. Use add_server to add one.")
             return '\n'.join(lines)
 
-        async def add_server(name: str) -> str:
-            """从配置文件加载并连接 MCP server。
+        async def add_server(
+            name: str,
+            transport: str = '',
+            command: str = '',
+            args: str = '',
+            url: str = '',
+            env: str = '',
+            description: str = '',
+        ) -> str:
+            """添加并连接 MCP server。可运行时传参或从配置加载。
 
-            :param name: server 名称，对应 mcp_hub 配置中 servers 的 key
+            :param name: server 名称
+            :param transport: 传输协议 (stdio / sse / streamable_http)。传参时必填
+            :param command: stdio: 可执行文件路径
+            :param args: stdio: 命令行参数，逗号分隔
+            :param url: sse/streamable_http: 服务 URL
+            :param env: 环境变量，逗号分隔的 KEY=VALUE 对
+            :param description: server 描述
             """
-            config = self._load_config()
-            if config is None:
-                return f"[MCP] Config 'mcp_hub.yml' not found in scoped storage ({' / '.join(self._scopes)})"
-
-            server_cfg = config.servers.get(name)
-            if server_cfg is None:
-                available = list(config.servers.keys())
-                return f"[MCP] Server '{name}' not in config. Available: {', '.join(available)}"
-
             if name in self._sessions and self._sessions[name].state == 'connected':
                 return f"[MCP:{name}] already connected"
+
+            config = self._load_config()
+
+            if transport:
+                parsed_env = {}
+                if env:
+                    for pair in env.split(','):
+                        pair = pair.strip()
+                        if '=' in pair:
+                            k, v = pair.split('=', 1)
+                            parsed_env[k.strip()] = v.strip()
+                parsed_args = [a.strip() for a in args.split(',') if a.strip()] if args else []
+                server_cfg = MCPServerConfig(
+                    name=name,
+                    transport=transport,  # type: ignore[arg-type]
+                    command=command,
+                    args=parsed_args,
+                    url=url,
+                    env=parsed_env,
+                    description=description,
+                )
+                config.servers[name] = server_cfg
+                self._save_config(config)
+            else:
+                server_cfg = config.servers.get(name)
+                if server_cfg is None:
+                    available = list(config.servers.keys())
+                    return f"[MCP] Server '{name}' not in config. Available: {', '.join(available)}"
+
             session = _MCPServerSession(config=server_cfg)
             await session.connect()
             self._sessions[name] = session
@@ -324,9 +364,6 @@ class MCPHubState(ChannelState):
             await session.disconnect()
             await session.connect()
             return f"[MCP:{name}] {session.state}" + (f": {session.error}" if session.error else '')
-
-        async def get_instruction() -> str:
-            return _DEFAULT_INSTRUCTION
 
         self._own_commands = {
             'exec': PyCommand(exec_cmd, blocking=False, always_observe=True),
@@ -360,17 +397,26 @@ class MCPHubState(ChannelState):
     def get_own_command(self, name: str) -> Command | None:
         return self._own_commands.get(name)
 
-    def _load_config(self) -> MCPHubConfig | None:
-        """加载 MCP Hub 配置。有 scopes 走 scoped storage YAML，无 scopes 走全局 ConfigStore。"""
+    def _load_config(self) -> MCPHubConfig:
+        """加载 MCP Hub 配置。有 scopes 走 scoped storage YAML，无 scopes 走全局 ConfigStore。
+        首次调用自动初始化空配置并持久化。
+        """
         if self._scopes:
             storage = self._matrix.get_scoped_storage(*self._scopes)
-            return storage.read_yaml("mcp_hub", MCPHubConfig)
+            config = storage.read_yaml("mcp_hub", MCPHubConfig)
+            if config is None:
+                config = MCPHubConfig(servers={})
+                storage.write_yaml("mcp_hub", config)
+            return config
         else:
             try:
                 from ghoshell_moss.contracts.configs import get_conf
                 return get_conf(ChannelCtx.container(), MCPHubConfig)
             except Exception:
-                return None
+                config = MCPHubConfig(servers={})
+                from ghoshell_moss.contracts.configs import save_conf
+                save_conf(ChannelCtx.container(), config)
+                return config
 
     def _save_config(self, config: MCPHubConfig) -> None:
         """持久化 MCP Hub 配置。"""
@@ -384,8 +430,6 @@ class MCPHubState(ChannelState):
     async def on_startup(self) -> None:
         """启动时加载配置并连接所有 server。"""
         config = self._load_config()
-        if config is None:
-            return
 
         for name, server_cfg in config.servers.items():
             session = _MCPServerSession(config=server_cfg)
@@ -399,7 +443,7 @@ class MCPHubState(ChannelState):
         self._sessions.clear()
 
     async def get_context_messages(self) -> list[str]:
-        """动态生成 server 状态和工具目录。"""
+        """动态生成 server 状态、工具目录和参数定义。"""
         lines = ["### MCP Tools"]
         for name, session in self._sessions.items():
             state_mark = {'connected': '+', 'connecting': '~', 'disconnected': '-', 'error': '!'}.get(
@@ -410,6 +454,9 @@ class MCPHubState(ChannelState):
                 for tool in session.tools:
                     desc = (tool.description or '').split('\n')[0][:120]
                     lines.append(f"  - `{tool.name}`: {desc}")
+                    params = _render_input_schema(tool.inputSchema)
+                    if params:
+                        lines.append(f"    params: {params}")
             elif session.error:
                 lines.append(f"  error: {session.error[:200]}")
             lines.append("")
@@ -433,7 +480,7 @@ class MCPHubChannel(Channel):
     ):
         self._name = name
         self._description = description or 'MCP Hub — 管理外部 MCP 工具调用'
-        self._scopes = scopes or ['ghost', 'mode']
+        self._scopes = scopes or []
         self._id = unique_id()
 
     def name(self) -> ChannelName:


### PR DESCRIPTION
…ation, get_or_create, runtime params, redundant instruction, tool inputSchema coding by deepseek-v4-pro

Issue 1: fix default scopes from ['ghost','mode'] to [] (ConfigStore path)
Issue 2: register MCPHubConfig in manifests/configs.py
Issue 3: add_server supports runtime connection parameters
Issue 4: _load_config get-or-create auto-init empty config
Issue 6: remove hand-written _DEFAULT_INSTRUCTION
Issue 7: render tool inputSchema in context messages

via claude code