### PR TITLE
fix: resolve env vars at connect-time, store $VAR placeholder in config

### DIFF
--- a/src/ghoshell_moss/channels/mcp_hub.py
+++ b/src/ghoshell_moss/channels/mcp_hub.py
@@ -35,12 +35,29 @@ except ImportError:
 
 __all__ = ['MCPHubChannel', 'build_mcp_hub_channel', 'MCPHubState',
            'MCPServerConfig', 'MCPHubConfig', 'MCPServerSession',
-           'mcp_result_to_observe', 'render_input_schema']
+           'mcp_result_to_observe', 'render_input_schema', 'resolve_env_dict']
 
 
 # ---------------------------------------------------------------------------
 # Config models
 # ---------------------------------------------------------------------------
+
+def resolve_env_dict(env: dict[str, str]) -> dict[str, str]:
+    """解析 env dict 中以 $ 开头的值，从 os.environ 读取实际值。
+
+    Config 文件中存储 $VAR_NAME 占位符，连接时由此函数解析为真值。
+    不以 $ 开头的值原样返回。
+    """
+    if not env:
+        return env
+    resolved = {}
+    for k, v in env.items():
+        if v.startswith('$'):
+            resolved[k] = os.environ.get(v[1:], v)
+        else:
+            resolved[k] = v
+    return resolved
+
 
 class MCPServerConfig(BaseModel):
     """单个 MCP server 的连接配置。"""
@@ -117,10 +134,11 @@ class MCPServerSession:
     async def _connect_transport(self):
         cfg = self.config
         if cfg.transport == 'stdio':
+            resolved_env = resolve_env_dict(cfg.env) if cfg.env else None
             params = StdioServerParameters(
                 command=cfg.command,
                 args=cfg.args or [],
-                env={**cfg.env} if cfg.env else None,
+                env=resolved_env,
             )
             transport = await self._exit_stack.enter_async_context(stdio_client(params))
             return transport
@@ -322,13 +340,12 @@ class MCPHubState(ChannelState):
                             k, v = pair.split('=', 1)
                             k, v = k.strip(), v.strip()
                             if v.startswith('$'):
-                                resolved = os.environ.get(v[1:], '')
-                                if not resolved:
+                                if v[1:] not in os.environ:
                                     return (
                                         f"[MCP:{name}] env var '{v[1:]}' not set. "
-                                        f"请在系统环境变量中配置 {v[1:]} 后重试。"
+                                        f"请在环境变量中配置 {v[1:]} 后重试。"
                                     )
-                                v = resolved
+                                # 存储 $VAR 占位符，解析为真值在 _connect_transport 中进行
                             parsed_env[k] = v
                 parsed_args = [a.strip() for a in args.split(',') if a.strip()] if args else []
                 server_cfg = MCPServerConfig(


### PR DESCRIPTION
Description:                                                                                                                                                         
   
  Summary                                                                                                                                                              
                                                            
  add_server now supports $ENV_VAR syntax in the env parameter. Values starting with $ are validated at save time but stored as placeholders in YAML config — real     
  values are resolved from os.environ only at connection time. Prevents API keys from leaking in CTML conversation history and YAML config files.
                                                                                                                                                                       
  Changes                                                                                                                                                              
   
  - add_server env parsing: BAIDU_MAPS_API_KEY=$BAIDU_MAPS_API_KEY validates the env var exists, stores $BAIDU_MAPS_API_KEY literally in config                        
  - resolve_env_dict() — resolves $VAR placeholders to real values at connection time in _connect_transport
  - Both runtime add_server and on_startup auto-connect go through the same resolution path                                                                            
  - Plain values (no $ prefix) pass through unchanged — backward compatible                                                                                            
  - Added third-party MCP server API key template to .env.example                                                                                                      
  - resolve_env_dict exported in __all__ for app reuse                                                                                                                 
                                                                                                                                                                       
  Usage                                                                                                                                                                
                                                                                                                                                                       
  Human configures in .moss_ws/.env:                                                                                                                                   
  BAIDU_MAPS_API_KEY=ustydslG7i6ZR550YmFUKsW3TP6ANsvU
                                                                                                                                                                       
  Model writes:                                                                                                                                                        
  <mcp:add_server name="baidu" transport="stdio" command="mcp-server-baidu-maps"                                                                                       
    env="BAIDU_MAPS_API_KEY=$BAIDU_MAPS_API_KEY" />                                                                                                                    
                                                                                                                                                                       
  Config YAML stores only the placeholder:                                                                                                                             
  env:                                                                                                                                                                 
    BAIDU_MAPS_API_KEY: $BAIDU_MAPS_API_KEY                                                                                                                            
                                                                                                                                                                       
  The real key never appears in CTML or on disk. 