### PR TITLE
refactor: MCPServerPreset with name-only add_server and compact context discovery

### DIFF
--- a/.ai_partners/features/workstreams/2026/06/mcp-hub-channel/FEATURE.md
+++ b/.ai_partners/features/workstreams/2026/06/mcp-hub-channel/FEATURE.md
@@ -5,7 +5,7 @@ description: MCP Hub — 将 MCP 协议降级为纯 transport，CTML 接管调�
 milestone: null
 priority: P0
 status: completed
-status_note: 2026-06-08 预设配置重构完成 — 删除 MCPServerPreset 类，改 YAML 配置。add_server name-only + $ENV_VAR connect-time 解析 + 紧凑 context 连接状态 + 54 单测通过。人类工程师 review 合并。
+status_note: 2026-06-08 预设配置重构完成 — 删除 MCPServerPreset 类，改 YAML 配置。add_server name-only + $ENV_VAR connect-time 解析 + context 含 description + _load_global_config 修复 + env 写盘自动 redact。54 单测通过。人类工程师 review 合并。
 title: MCP Hub Channel
 updated: '2026-06-08'
 ---

--- a/.ai_partners/features/workstreams/2026/06/mcp-hub-channel/FEATURE.md
+++ b/.ai_partners/features/workstreams/2026/06/mcp-hub-channel/FEATURE.md
@@ -5,9 +5,9 @@ description: MCP Hub — 将 MCP 协议降级为纯 transport，CTML 接管调�
 milestone: null
 priority: P0
 status: completed
-status_note: 2026-06-07 全链路验证通过 + 6 issues 修复 + moss-repl 验收 + 24 单测 + stubs 同步。人类工程师 review 合并。
+status_note: 2026-06-08 预设配置重构完成 — 删除 MCPServerPreset 类，改 YAML 配置。add_server name-only + $ENV_VAR connect-time 解析 + 紧凑 context 连接状态 + 54 单测通过。人类工程师 review 合并。
 title: MCP Hub Channel
-updated: '2026-06-07'
+updated: '2026-06-08'
 ---
 
 # MCP Hub Channel
@@ -281,3 +281,65 @@ MCP Hub 的运行时 `add_server` 使得封装 MCP server 为独立 app 完全�
 - 模型视角不变 — 始终通过 `mcp:exec` 调用，无论 server 来自预配置还是运行时添加
 
 `mcp/baidu_map` app 目录已移除。保留此节作为设计演进的记录。
+
+## 预设配置重构 (2026-06-08)
+
+### 动机
+
+经过两轮迭代，最终删除了 `MCPServerPreset` 类。MCP server 预设直接写在
+`mcp_hub.yml` 的 `servers` 字段中——YAML 即配置，无需 Python 类层次结构、
+ConfigStore 注册和 `__init_subclass__` 魔法。
+
+### 设计
+
+**`mcp_hub.yml` 全局预设**（`.moss_ws/configs/mcp_hub.yml`）：
+
+```yaml
+servers:
+  baidu_map:
+    name: baidu_map
+    transport: stdio
+    command: mcp-server-baidu-maps
+    description: Baidu Maps — location search, geocoding, directions, weather, traffic, and POI extraction
+    env:
+      BAIDU_MAPS_API_KEY: $BAIDU_MAPS_API_KEY
+```
+
+**`add_server(name)` 查找**：
+
+1. 当前活跃 config（scoped 或全局）的 `servers[name]`
+2. 如果活跃 config 有 scopes → 全局 `mcp_hub.yml` 作为预设 fallback
+3. 未找到 → 列出两端合并后的可用名称
+
+全局 `mcp_hub.yml` 是所有 Ghost 共享的预设目录。Scoped `mcp_hub.yml`
+可额外配置 ghost 专属 server。
+
+**模型 CTML**：
+
+```xml
+<mcp:add_server name="baidu_map" />
+```
+
+### 安全模型
+
+- CTML 中：仅 name，零敏感信息
+- YAML 落盘：`$BAIDU_MAPS_API_KEY` 占位符，不存真值
+- 连接时：`resolve_env_dict()` 从 `os.environ` 解析 `$VAR` → 真值
+
+### Context messages — 紧凑暴露可用列表
+
+`get_context_messages` 始终展示当前 MCP 连接状态全景：已连接 server 的 tool
+目录 + 未连接 preset 的紧凑列表。
+
+```
+### MCP Tools
+[+] **baidu_map**
+  - `map_weather`: ...
+Available: other_preset
+
+### MCP Tools
+No MCP servers connected. Available: baidu_map
+```
+
+**设计决策**：模型需要始终知道当前有哪些 MCP 可用、哪些已连接。可用列表仅
+列名称，一行 `name, name, ...` 不浪费 token。

--- a/.moss_ws/configs/mcp_hub.yml
+++ b/.moss_ws/configs/mcp_hub.yml
@@ -2,6 +2,17 @@
 # 此处定义的 server 对所有 Ghost 可见，通过 <mcp:add_server name="..." /> 连接。
 # env 中以 $ 开头的值在连接时从系统环境变量解析为真值，此处存储 $VAR 占位符。
 servers:
+  test:
+    name: test
+    transport: stdio
+    command: .venv/bin/python
+    description: Local MCP test server — echo, add, get_time, slow_echo
+    args:
+    - scripts/mcp_test_server.py
+    - --stdio
+    env: {}
+    url: ''
+    headers: {}
   baidu_map:
     name: baidu_map
     transport: stdio

--- a/.moss_ws/configs/mcp_hub.yml
+++ b/.moss_ws/configs/mcp_hub.yml
@@ -1,0 +1,14 @@
+# MCP Hub 全局预设配置。
+# 此处定义的 server 对所有 Ghost 可见，通过 <mcp:add_server name="..." /> 连接。
+# env 中以 $ 开头的值在连接时从系统环境变量解析为真值，此处存储 $VAR 占位符。
+servers:
+  baidu_map:
+    name: baidu_map
+    transport: stdio
+    command: mcp-server-baidu-maps
+    description: Baidu Maps — location search, geocoding, directions, weather, traffic, and POI extraction
+    args: []
+    env:
+      BAIDU_MAPS_API_KEY: $BAIDU_MAPS_API_KEY
+    url: ''
+    headers: {}

--- a/src/ghoshell_moss/channels/mcp_hub.py
+++ b/src/ghoshell_moss/channels/mcp_hub.py
@@ -60,7 +60,7 @@ def resolve_env_dict(env: dict[str, str]) -> dict[str, str]:
 
 
 class MCPServerConfig(BaseModel):
-    """单个 MCP server 的连接配置。"""
+    """单个 MCP server 的连接配置（运行时使用，非模型可见）。"""
 
     name: str = Field(description="server 名称，作为 exec 的 server 参数")
     transport: Literal['stdio', 'sse', 'streamable_http'] = Field(
@@ -307,63 +307,30 @@ class MCPHubState(ChannelState):
                 lines.append("No servers configured. Use add_server to add one.")
             return '\n'.join(lines)
 
-        async def add_server(
-            name: str,
-            transport: str = '',
-            command: str = '',
-            args: str = '',
-            url: str = '',
-            env: str = '',
-            description: str = '',
-        ) -> str:
-            """添加并连接 MCP server。可运行时传参或从配置加载。
+        async def add_server(name: str) -> str:
+            """添加并连接 MCP server。
 
-            :param name: server 名称
-            :param transport: 传输协议 (stdio / sse / streamable_http)。传参时必填
-            :param command: stdio: 可执行文件路径
-            :param args: stdio: 命令行参数，逗号分隔
-            :param url: sse/streamable_http: 服务 URL
-            :param env: 环境变量，逗号分隔的 KEY=VALUE 对。value 以 $ 开头时从系统环境变量读取（如 BAIDU_MAPS_API_KEY=$BAIDU_MAPS_API_KEY），避免在 CTML 中暴露敏感信息
-            :param description: server 描述
+            :param name: server 名称，对应 mcp_hub.yml 中配置的 server 名
             """
             if name in self._sessions and self._sessions[name].state == 'connected':
                 return f"[MCP:{name}] already connected"
 
+            # 1. 当前活跃配置（scoped 或全局）
             config = self._load_config()
+            server_cfg = config.servers.get(name)
 
-            if transport:
-                parsed_env = {}
-                if env:
-                    for pair in env.split(','):
-                        pair = pair.strip()
-                        if '=' in pair:
-                            k, v = pair.split('=', 1)
-                            k, v = k.strip(), v.strip()
-                            if v.startswith('$'):
-                                if v[1:] not in os.environ:
-                                    return (
-                                        f"[MCP:{name}] env var '{v[1:]}' not set. "
-                                        f"请在环境变量中配置 {v[1:]} 后重试。"
-                                    )
-                                # 存储 $VAR 占位符，解析为真值在 _connect_transport 中进行
-                            parsed_env[k] = v
-                parsed_args = [a.strip() for a in args.split(',') if a.strip()] if args else []
-                server_cfg = MCPServerConfig(
-                    name=name,
-                    transport=transport,  # type: ignore[arg-type]
-                    command=command,
-                    args=parsed_args,
-                    url=url,
-                    env=parsed_env,
-                    description=description,
-                )
-                config.servers[name] = server_cfg
-                self._save_config(config)
-            else:
-                server_cfg = config.servers.get(name)
-                if server_cfg is None:
-                    available = list(config.servers.keys())
-                    return f"[MCP] Server '{name}' not in config. Available: {', '.join(available)}"
+            # 2. 全局预设 fallback（仅当活跃配置有 scopes 时额外查全局）
+            if server_cfg is None and self._scopes:
+                global_config = self._load_global_config()
+                server_cfg = global_config.servers.get(name)
+
+            # 3. 未找到 → 列出可用 server
+            if server_cfg is None:
+                available = set(config.servers.keys())
+                if self._scopes:
+                    available.update(self._load_global_config().servers.keys())
+                suffix = f". Available: {', '.join(sorted(available))}" if available else ''
+                return f"[MCP:{name}] not found{suffix}"
 
             session = MCPServerSession(config=server_cfg)
             await session.connect()
@@ -455,6 +422,18 @@ class MCPHubState(ChannelState):
             from ghoshell_moss.contracts.configs import save_conf
             save_conf(ChannelCtx.container(), config)
 
+    def _load_global_config(self) -> MCPHubConfig:
+        """加载全局 MCP Hub 预设配置（只读，直接读 workspace configs/ 目录）。"""
+        try:
+            workspace = self._matrix.cell_workspace()
+            store = YamlConfigStore(workspace.configs())
+            config = store.read_yaml("mcp_hub", MCPHubConfig)
+            if config is not None:
+                return config
+        except Exception:
+            pass
+        return MCPHubConfig(servers={})
+
     async def on_startup(self) -> None:
         """启动时加载配置并连接所有 server。"""
         config = self._load_config()
@@ -471,7 +450,7 @@ class MCPHubState(ChannelState):
         self._sessions.clear()
 
     async def get_context_messages(self) -> list[str]:
-        """动态生成 server 状态、工具目录和参数定义。"""
+        """动态生成 server 状态、工具目录、参数定义和可用 preset。"""
         lines = ["### MCP Tools"]
         for name, session in self._sessions.items():
             state_mark = {'connected': '+', 'connecting': '~', 'disconnected': '-', 'error': '!'}.get(
@@ -488,8 +467,19 @@ class MCPHubState(ChannelState):
             elif session.error:
                 lines.append(f"  error: {session.error[:200]}")
             lines.append("")
-        if not self._sessions:
-            lines.append("No MCP servers connected.")
+        # 未连接的 YAML 预配置（活跃 config + 全局预设）
+        config = self._load_config()
+        available: set[str] = set(config.servers.keys())
+        if self._scopes:
+            available.update(self._load_global_config().servers.keys())
+        available.difference_update(self._sessions.keys())
+        if available:
+            if self._sessions:
+                lines.append(f"Available: {', '.join(sorted(available))}")
+            else:
+                lines.append(f"No MCP servers connected. Available: {', '.join(sorted(available))}")
+        elif not self._sessions:
+            lines.append("No MCP servers available.")
         return ['\n'.join(lines)]
 
 

--- a/src/ghoshell_moss/channels/mcp_hub.py
+++ b/src/ghoshell_moss/channels/mcp_hub.py
@@ -19,7 +19,7 @@ from ghoshell_moss.core.concepts.channel import Channel, ChannelName, ChannelRun
 from ghoshell_moss.core.concepts.command import Command, Observe
 from ghoshell_moss.core.blueprint.states_channel import new_stateful_channel_from_main, ChannelState
 from ghoshell_moss.core.blueprint.matrix import Matrix, ScopesKey
-from ghoshell_moss.contracts.configs import ConfigType, YamlConfigStore
+from ghoshell_moss.contracts.configs import ConfigType
 from ghoshell_moss.message import Message, Text, Base64Image, unique_id
 from ghoshell_container import IoCContainer
 from pydantic import BaseModel, Field
@@ -57,6 +57,25 @@ def resolve_env_dict(env: dict[str, str]) -> dict[str, str]:
         else:
             resolved[k] = v
     return resolved
+
+
+def _redact_env_for_save(env: dict[str, str]) -> dict[str, str]:
+    """resolve_env_dict 的逆向：将 env 真值还原为 $VAR 占位符。
+
+    扫描 os.environ，若 env value 与某个环境变量值匹配，替换为 $VAR_NAME。
+    不匹配的值原样保留。
+    """
+    if not env:
+        return env
+    redacted = {}
+    for k, v in env.items():
+        for env_key, env_val in os.environ.items():
+            if v == env_val:
+                redacted[k] = f"${env_key}"
+                break
+        else:
+            redacted[k] = v
+    return redacted
 
 
 class MCPServerConfig(BaseModel):
@@ -414,7 +433,10 @@ class MCPHubState(ChannelState):
                 return config
 
     def _save_config(self, config: MCPHubConfig) -> None:
-        """持久化 MCP Hub 配置。"""
+        """持久化 MCP Hub 配置。保存前将 env 真值还原为 $VAR 占位符。"""
+        for server_cfg in config.servers.values():
+            if server_cfg.env:
+                server_cfg.env = _redact_env_for_save(server_cfg.env)
         if self._scopes:
             storage = self._matrix.get_scoped_storage(*self._scopes)
             storage.write_yaml("mcp_hub", config)
@@ -425,9 +447,8 @@ class MCPHubState(ChannelState):
     def _load_global_config(self) -> MCPHubConfig:
         """加载全局 MCP Hub 预设配置（只读，直接读 workspace configs/ 目录）。"""
         try:
-            workspace = self._matrix.cell_workspace()
-            store = YamlConfigStore(workspace.configs())
-            config = store.read_yaml("mcp_hub", MCPHubConfig)
+            workspace = self._matrix.workspace
+            config = workspace.configs().read_yaml("mcp_hub", MCPHubConfig)
             if config is not None:
                 return config
         except Exception:
@@ -467,17 +488,21 @@ class MCPHubState(ChannelState):
             elif session.error:
                 lines.append(f"  error: {session.error[:200]}")
             lines.append("")
-        # 未连接的 YAML 预配置（活跃 config + 全局预设）
+        # 未连接的 YAML 预配置（活跃 config + 全局预设），含描述
         config = self._load_config()
-        available: set[str] = set(config.servers.keys())
-        if self._scopes:
-            available.update(self._load_global_config().servers.keys())
-        available.difference_update(self._sessions.keys())
+        available: dict[str, str] = {}
+        for src in [config] + ([self._load_global_config()] if self._scopes else []):
+            for name, cfg in src.servers.items():
+                if name not in self._sessions and name not in available:
+                    available[name] = cfg.description or ''
         if available:
             if self._sessions:
-                lines.append(f"Available: {', '.join(sorted(available))}")
+                lines.append("Available:")
             else:
-                lines.append(f"No MCP servers connected. Available: {', '.join(sorted(available))}")
+                lines.append("No MCP servers connected. Available:")
+            for name in sorted(available):
+                desc = f" — {available[name]}" if available[name] else ''
+                lines.append(f"- `{name}`{desc}")
         elif not self._sessions:
             lines.append("No MCP servers available.")
         return ['\n'.join(lines)]

--- a/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/configs.py
+++ b/src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/configs.py
@@ -28,3 +28,4 @@ audio_player_config = AudioPlayerConfig()
 audio_capture_config = AudioCaptureConfig()
 
 mcp_hub_config = MCPHubConfig()
+

--- a/tests/ghoshell_moss/channels/test_mcp_hub.py
+++ b/tests/ghoshell_moss/channels/test_mcp_hub.py
@@ -284,7 +284,7 @@ class TestMCPHubStateStructure:
     async def test_add_server_without_config(self, state):
         cmd = state.get_own_command("add_server")
         result = await cmd(name="nonexistent")
-        assert "not in config" in result.lower()
+        assert "not found" in result.lower()
 
     @pytest.mark.asyncio
     async def test_remove_nonexistent_server(self, state):
@@ -572,10 +572,10 @@ class TestLoadConfigGetOrCreate:
 
 
 # ---------------------------------------------------------------------------
-# Issue 3: add_server runtime params
+# add_server: scoped config save/load
 # ---------------------------------------------------------------------------
 
-class TestRuntimeAddServer:
+class TestAddServerConfig:
     @pytest.fixture
     def matrix_storage(self):
         from unittest.mock import MagicMock


### PR DESCRIPTION
Description:                                                                                                                                                         
   
  Summary                                                                                                                                                              
                                                        
  - add_server(name) is name-only — connection params are looked up from mcp_hub.yml presets at connect time, zero sensitive info in CTML                              
  - mcp_hub.yml as global server preset catalog, shared across all ghosts
  - $ENV_VAR placeholders stored in YAML, resolved from os.environ at connect time via resolve_env_dict                                                                
  - Two-tier config: scoped storage for ghost-specific servers, global mcp_hub.yml for shared presets                                                                  
  - Auto-connect on startup from active config; available presets listed in context with descriptions                                                                  
                                                                                                                                                                       
  Context messages                                                                                                                                                     
                                                                                                                                                                       
  - Connected servers: [+] name + tool catalog with render_input_schema parameter definitions                                                                          
  - Available presets: - \name` — description`          
                                                                                                                                                                       
  Bug fixes                                                                                                                                                            
                                                                                                                                                                       
  - _load_global_config: fix config loading path for global preset discovery                                                                                           
  - API key leak prevention: _redact_env_for_save replaces env values with $VAR placeholders before persisting
  - Remove unused YamlConfigStore import and hand-written instruction string (framework auto-reflects command signatures)                                              
                                                                                                                                                                       
  Files changed                                                                                                                                                        
                                                                                                                                                                       
  - src/ghoshell_moss/channels/mcp_hub.py — core implementation                                                                                                        
  - .moss_ws/configs/mcp_hub.yml — global presets (test)
  - src/ghoshell_moss/host/stubs/workspace/src/MOSS/manifests/configs.py — MCPHubConfig registration                                                                   
  - tests/ghoshell_moss/channels/test_mcp_hub.py — mock adaptation                                                                                                     
  - .ai_partners/features/workstreams/2026/06/mcp-hub-channel/FEATURE.md — design doc