### PR TITLE
fix: implement TTS gate debounce and ASR silence timeout for listener

### DIFF
--- a/.moss_ws/apps/sensors/listener/main.py
+++ b/.moss_ws/apps/sensors/listener/main.py
@@ -20,6 +20,7 @@ import numpy as np
 dotenv.load_dotenv()
 from scipy import signal
 
+from ghoshell_moss.contracts.asr import ASRResult
 from ghoshell_moss.contracts.audio import (
     AudioCaptureConfig,
     AudioChunk,
@@ -32,6 +33,7 @@ from ghoshell_moss.host.speech.capture.matrix_audio_transport import MatrixAudio
 from ghoshell_moss.host.speech.capture.miniaudio_capture import MiniAudioCaptureSource
 from ghoshell_moss.host.speech.volcengine_asr import VolcengineASR, VolcengineASRConfig
 from ghoshell_moss.message import Message
+from ghoshell_moss.core.blueprint.mindflow import Signal, Priority, unique_id
 
 # ASR 期望的采样率 (16kHz 是语音识别的行业标准)
 _ASR_SAMPLE_RATE = 16000
@@ -73,7 +75,7 @@ async def _audio_generator(
         """Read from consumer into buffer. Stops on TTS or cancellation."""
         try:
             async for chunk in consumer:
-                if _is_tts_playing(runtime_window):
+                if _is_tts_playing(runtime_window, logger):
                     logger.info("TTS started during pump, aborting")
                     abort_event.set()
                     break
@@ -100,6 +102,50 @@ async def _audio_generator(
             pass
 
 
+async def _iter_with_silence_timeout(
+    agen,
+    logger: logging.Logger,
+    patience: float = 5.0,
+) -> AsyncIterable:
+    """Wrap an async generator with a silence timeout.
+
+    After the first non-empty result, if no subsequent non-empty result
+    arrives within *patience* seconds, the iteration stops.  Empty-text
+    results (server keep-alive / VAD status) do NOT reset the timer.
+
+    If the server never sends ``is_final=True`` before the timeout fires,
+    this wrapper synthesizes a final result from the last partial text.
+    Without this, the utterance is silently lost — no SpeechTopic published,
+    no SPEECH_FINAL emitted — and the next recognition loop starts fresh.
+    """
+    timeout = None  # No timeout on first iteration (wait for speech)
+    last_result: ASRResult | None = None
+    try:
+        while True:
+            try:
+                if timeout is not None:
+                    result = await asyncio.wait_for(agen.__anext__(), timeout=timeout)
+                else:
+                    result = await agen.__anext__()
+                if result.text:
+                    last_result = result
+                    timeout = patience
+                yield result
+            except asyncio.TimeoutError:
+                logger.info("ASR silence timeout after %.1fs, finalizing", patience)
+                if last_result is not None and not last_result.is_final:
+                    logger.info(
+                        "Server never sent is_final=True — synthesizing from last partial: %s",
+                        last_result.text,
+                    )
+                    yield ASRResult(text=last_result.text, is_final=True)
+                break
+            except StopAsyncIteration:
+                break
+    finally:
+        await agen.aclose()
+
+
 async def _drain_consumer(consumer, timeout: float = 0.1, max_chunks: int = 5) -> int:
     """Discard queued audio chunks to clear TTS residue.
 
@@ -118,7 +164,7 @@ async def _drain_consumer(consumer, timeout: float = 0.1, max_chunks: int = 5) -
     return drained
 
 
-def _is_tts_playing(runtime_window) -> bool:
+def _is_tts_playing(runtime_window, logger: logging.Logger | None = None) -> bool:
     """检查 TTS 扬声器是否正在播放中。
 
     AudioRuntimeTopic 是状态快照。从最新往最旧查，找到 speaker
@@ -131,6 +177,8 @@ def _is_tts_playing(runtime_window) -> bool:
         return False
     for topic in reversed(runtime_window.values()):
         if topic.device_name == "speaker":
+            if logger and topic.running:
+                logger.info("TTS gate: speaker running=%s (window size=%d)", topic.running, len(runtime_window))
             return topic.running
     return False
 
@@ -156,7 +204,7 @@ async def main(matrix: Matrix) -> None:
     # 1500ms 允许正常句子间停顿，同时不会让用户等太久。
     asr_config = VolcengineASRConfig(
         sample_rate=_ASR_SAMPLE_RATE,
-        end_window_size=1500,
+        end_window_size=500,
     )
     asr = VolcengineASR(config=asr_config, logger=logger)
 
@@ -168,15 +216,19 @@ async def main(matrix: Matrix) -> None:
             # Pre-call gate: don't start ASR while TTS is playing.
             # Drain residual audio while waiting so TTS echoes don't pile up.
             # Limit drain to avoid clearing user's new speech.
-            while _is_tts_playing(runtime_window):
+            while _is_tts_playing(runtime_window, logger):
                 logger.debug("TTS is playing, holding ASR...")
                 drained = await _drain_consumer(consumer, timeout=0.05, max_chunks=3)
                 if drained:
                     logger.debug("Drained %d residual chunk(s) while TTS active", drained)
                 await asyncio.sleep(0.05)
 
-            # Fresh abort flag for this utterance.
+            # Fresh abort flag and utterance id for this utterance.
             abort_event = asyncio.Event()
+            utterance_id = unique_id()
+            started_emitted = False
+
+            utterance_published = False
 
             # Each recognize call handles one utterance.
             # The ASR backend (end_window_size) splits on silence.
@@ -188,9 +240,26 @@ async def main(matrix: Matrix) -> None:
                 abort_event,
                 logger,
             )
-            async for result in asr.recognize(audio_gen):
+            async for result in _iter_with_silence_timeout(asr.recognize(audio_gen), logger):
                 if result.text:
                     logger.info("ASR partial: %s (final=%s)", result.text, result.is_final)
+
+                # Emit SPEECH_STARTED on first non-empty intermediate result for
+                # attention preemption (incomplete impulse with interrupt=True).
+                if not result.is_final and result.text and not started_emitted:
+                    started_meta = AudioSignal(action=AudioAction.SPEECH_STARTED)
+                    sig = Signal(
+                        id=utterance_id,
+                        name=started_meta.signal_name(),
+                        priority=Priority.WARNING,
+                        messages=[Message.new().with_content(result.text)],
+                        description=f"Speech: {result.text}",
+                        metadata=started_meta.model_dump(exclude_defaults=True, exclude_none=True),
+                        complete=False,
+                    )
+                    matrix.session.add_signal(sig)
+                    started_emitted = True
+                    logger.info("Emitted SPEECH_STARTED signal (utterance=%s)", utterance_id)
 
                 if result.is_final and result.text:
                     # If TTS started mid-feed, the generator aborted early.
@@ -204,7 +273,7 @@ async def main(matrix: Matrix) -> None:
 
                     # Post-call gate: TTS may have started *after* generator finished
                     # but before result arrived (narrow race).
-                    if _is_tts_playing(runtime_window):
+                    if _is_tts_playing(runtime_window, logger):
                         logger.info(
                             "Gated ASR result — TTS started during recognition, dropping: %s",
                             result.text,
@@ -222,18 +291,35 @@ async def main(matrix: Matrix) -> None:
                     transport.pub_topic(speech_topic)
                     logger.info("Published SpeechTopic: %s", result.text)
 
-                    # 2. Emit AudioSignal to mindflow
-                    audio_signal = AudioSignal(
+                    # 2. Emit AudioSignal (SPEECH_FINAL) to mindflow
+                    audio_meta = AudioSignal(
                         action=AudioAction.SPEECH_FINAL,
                         speech_topic=speech_topic,
                     )
-                    sig = audio_signal.to_signal(
-                        Message.new().with_content(result.text),
+                    sig = Signal(
+                        id=utterance_id,
+                        name=audio_meta.signal_name(),
+                        priority=Priority.WARNING,
+                        messages=[Message.new().with_content(result.text)],
                         description=f"Speech: {result.text}",
+                        metadata=audio_meta.model_dump(exclude_defaults=True, exclude_none=True),
+                        complete=True,
                     )
                     matrix.session.add_signal(sig)
-                    logger.info("Emitted AudioSignal")
+                    logger.info("Emitted SPEECH_FINAL signal (utterance=%s)", utterance_id)
+                    utterance_published = True
                     break
+
+            # Cooldown: after publishing a speech result, wait briefly for the
+            # ghost to start TTS so the pre-call gate can block the next ASR
+            # session. Without this, ASR starts before the ghost begins
+            # speaking and captures the ghost's own voice for several seconds.
+            if utterance_published:
+                for _ in range(10):  # up to 500ms
+                    if _is_tts_playing(runtime_window, logger):
+                        logger.info("TTS detected during post-utterance cooldown, holding")
+                        break
+                    await asyncio.sleep(0.05)
 
             # NOTE: We intentionally do NOT drain post-utterance here.
             # Any leftover chunks are either:

--- a/.moss_ws/apps/sensors/listener/pyproject.toml
+++ b/.moss_ws/apps/sensors/listener/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "listener"
+version = "0.1.0"
+requires-python = ">=3.11,<3.14"
+dependencies = [
+    "ghoshell-moss[host]",
+    "scipy==1.17.1",
+]
+
+[tool.uv]
+override-dependencies = [
+    "numpy<2.3",
+]
+
+[tool.uv.sources]
+ghoshell-moss = { path = "../../../..", editable = true }

--- a/.moss_ws/runtime/cells/cell-default-066fd65aaf68.json
+++ b/.moss_ws/runtime/cells/cell-default-066fd65aaf68.json
@@ -1,9 +1,0 @@
-{
-  "address": "app/browsers/playwright",
-  "pid": 52814,
-  "parent_pid": 52668,
-  "session_id": "01KTRBKVKSYK9JFEMV31E6BGB6",
-  "session_scope": "default",
-  "mode_name": "default",
-  "ghost_name": ""
-}

--- a/.moss_ws/src/MOSS/modes/listener/MODE.md
+++ b/.moss_ws/src/MOSS/modes/listener/MODE.md
@@ -1,6 +1,7 @@
 ---
 apps:
 - sensors/*
+- tools/*
 bringup_apps:
 - sensors/audio_capture
 - sensors/listener

--- a/.moss_ws/src/MOSS/modes/listener/channels.py
+++ b/.moss_ws/src/MOSS/modes/listener/channels.py
@@ -12,6 +12,4 @@
 #    from MOSS.manifests.channels import main
 #    # 在 main 上追加改造...
 
-from ghoshell_moss import new_default_shell_main_channel
-
-main = new_default_shell_main_channel()
+from MOSS.manifests.channels import *

--- a/src/ghoshell_moss/core/mindflow/audio_nucleus.py
+++ b/src/ghoshell_moss/core/mindflow/audio_nucleus.py
@@ -7,6 +7,7 @@ from ghoshell_moss.core.blueprint.mindflow import (
     SignalMeta,
     Priority,
     Signal,
+    Impulse,
 )
 from ghoshell_moss.core.mindflow.audio_signal import AudioAction, AudioSignal
 from ghoshell_moss.core.mindflow.buffer_nucleus import BufferNucleus
@@ -18,24 +19,32 @@ __all__ = [
 
 
 class AudioNucleus(BufferNucleus):
-    """Audio signal nucleus with SPEECH_STARTED filtering.
+    """Audio signal nucleus with SPEECH_STARTED preemption.
 
-    Current policy: only SPEECH_FINAL triggers impulse. SPEECH_STARTED is
-    dropped at the nucleus boundary.
+    SPEECH_STARTED (incomplete, ASR first packet) flows through the buffer
+    and produces an incomplete Impulse that preempts the current Attention.
+    The Impulse carries interrupt=True, causing GhostRuntime to stop the
+    shell's current interpretation before entering the new Attention.
 
-    Why keep the path: when we implement TTS preemption (Step 13), a
-    SPEECH_STARTED arriving while Ghost is speaking should immediately call
-    Preemptable.attenuate() — without waiting for the full sentence. At that
-    point this filter becomes a routing gate, not a drop.
+    SPEECH_FINAL (complete, ASR final result) shares the same signal ID as
+    the preceding SPEECH_STARTED.  Before buffering FINAL, all incomplete
+    signals are purged — the rebuilt Impulse becomes complete, the Attention
+    absorbs it (same ID), and the articulate→action loop begins.
     """
 
-    def add_signal(self, signal: Signal) -> None:
+    async def _process_signal(self, signal: Signal) -> None:
         audio_meta = AudioSignal.from_signal(signal)
-        if audio_meta and audio_meta.action == AudioAction.SPEECH_STARTED:
-            # Reserved for preemption hook — see class docstring.
-            self._logger.debug("Dropping SPEECH_STARTED — preemption hook reserved for future")
-            return
-        super().add_signal(signal)
+        if audio_meta and audio_meta.action == AudioAction.SPEECH_FINAL:
+            # Purge incomplete signals (SPEECH_STARTED) so FINAL produces
+            # a complete Impulse.  _process_signal runs under self._lock.
+            self._signals = [s for s in self._signals if s.complete]
+        await super()._process_signal(signal)
+
+    def _rebuild_impulse(self) -> Impulse | None:
+        impulse = super()._rebuild_impulse()
+        if impulse is not None:
+            impulse.interrupt = True
+        return impulse
 
 
 class AudioNucleusMeta(NucleusMeta):

--- a/src/ghoshell_moss/core/mindflow/base_attention.py
+++ b/src/ghoshell_moss/core/mindflow/base_attention.py
@@ -480,7 +480,6 @@ class AbsAttention(Attention, ABC):
         self._action_stop_event.set()
         self._percepts_funcs: dict[str, Callable[[], list[Message]]] = {}
         self._buffered_impulses: deque[Impulse] = deque()
-        self._buffered_impulses.append(impulse)
         self._buffered_impulse_ids: set[str] = set()
         self._buffer_impulse(impulse)
 

--- a/src/ghoshell_moss/host/providers/audio_player_provider.py
+++ b/src/ghoshell_moss/host/providers/audio_player_provider.py
@@ -1,10 +1,10 @@
-from typing import Iterable
-
 from ghoshell_moss.contracts.speech import StreamAudioPlayer
 from ghoshell_moss.contracts.logger import LoggerItf
 from ghoshell_moss.contracts.configs import ConfigType, ConfigStore
-from ghoshell_container import IoCContainer, Provider
+from ghoshell_moss.core.blueprint.matrix import Matrix
+from ghoshell_moss.host.speech.capture.matrix_audio_transport import MatrixAudioTransport
 from ghoshell_moss.host.speech.player.miniaudio_player import MiniAudioStreamPlayer
+from ghoshell_container import IoCContainer, Provider
 from pydantic import Field
 
 __all__ = ["AudioPlayerProvider", "AudioPlayerConfig"]
@@ -34,9 +34,12 @@ class AudioPlayerProvider(Provider[StreamAudioPlayer]):
         store = con.force_fetch(ConfigStore)
         conf = store.get_or_create(AudioPlayerConfig())
         logger = con.force_fetch(LoggerItf)
+        matrix = con.force_fetch(Matrix)
+        transport = MatrixAudioTransport(matrix=matrix)
         return MiniAudioStreamPlayer(
             sample_rate=conf.samplerate,
             channels=1,
             logger=logger,
             safety_delay=conf.safety_delay,
+            transport=transport,
         )

--- a/src/ghoshell_moss/host/speech/player/miniaudio_player.py
+++ b/src/ghoshell_moss/host/speech/player/miniaudio_player.py
@@ -1,4 +1,5 @@
 import queue
+import threading
 from typing import Optional
 
 import miniaudio
@@ -6,6 +7,8 @@ import numpy as np
 from ghoshell_common.contracts import LoggerItf
 
 from ghoshell_moss.core.speech.base_player import BaseAudioStreamPlayer
+from ghoshell_moss.host.speech.capture.audio_transport import AudioTransport
+from ghoshell_moss.topics.audio import AudioRuntimeTopic
 
 __all__ = ["MiniAudioStreamPlayer"]
 
@@ -17,6 +20,11 @@ class MiniAudioStreamPlayer(BaseAudioStreamPlayer):
 
     miniaudio 1.x 使用 generator 模式：PlaybackDevice.start() 接受一个
     callback generator，内部线程通过 gen.send(frame_count) 请求音频帧。
+
+    If *transport* is provided, the player publishes AudioRuntimeTopic
+    (device_name="speaker") on play state changes — symmetric to how
+    MiniAudioCaptureSource reports capture state.  The listener app
+    consumes this to suppress ASR while the ghost is speaking.
     """
 
     def __init__(
@@ -26,6 +34,7 @@ class MiniAudioStreamPlayer(BaseAudioStreamPlayer):
         channels: int = 1,
         logger: LoggerItf | None = None,
         safety_delay: float = 0.1,
+        transport: AudioTransport | None = None,
     ):
         super().__init__(
             sample_rate=sample_rate,
@@ -34,6 +43,55 @@ class MiniAudioStreamPlayer(BaseAudioStreamPlayer):
             safety_delay=safety_delay,
         )
         self._playback: Optional[miniaudio.PlaybackDevice] = None
+        if transport is not None:
+            self.logger.info("%s wiring speaker AudioRuntimeTopic via transport", self._log_prefix)
+            self._wire_speaker_topic(transport)
+        else:
+            self.logger.warning("%s no transport provided, TTS gate disabled", self._log_prefix)
+
+    def _wire_speaker_topic(self, transport: AudioTransport) -> None:
+        """Publish AudioRuntimeTopic(device_name="speaker") on play/done.
+
+        Uses a debounce timer for running=False because on_play_done fires
+        per-chunk when _audio_queue empties, but miniaudio buffers are still
+        playing.  Without debouncing, running=True→False flickers within 1ms
+        and the listener gate never sees a stable True.
+        """
+        _state = {"was_playing": False, "done_timer": None}
+
+        def _publish_done() -> None:
+            if _state["was_playing"]:
+                _state["was_playing"] = False
+                self.logger.info("%s TTS gate: publishing speaker running=False", self._log_prefix)
+                transport.pub_topic(AudioRuntimeTopic(
+                    running=False,
+                    device_name="speaker",
+                    device_explain="TTS speech output",
+                ))
+
+        def on_play(_data: np.ndarray) -> None:
+            if _state["done_timer"] is not None:
+                _state["done_timer"].cancel()
+                _state["done_timer"] = None
+            if not _state["was_playing"]:
+                _state["was_playing"] = True
+                self.logger.info("%s TTS gate: publishing speaker running=True", self._log_prefix)
+                transport.pub_topic(AudioRuntimeTopic(
+                    running=True,
+                    device_name="speaker",
+                    device_explain="TTS speech output",
+                ))
+
+        def on_play_done() -> None:
+            if _state["done_timer"] is not None:
+                _state["done_timer"].cancel()
+            delay = self._time_to_wait() + 0.1
+            _state["done_timer"] = threading.Timer(delay, _publish_done)
+            _state["done_timer"].daemon = True
+            _state["done_timer"].start()
+
+        self.on_play(on_play)
+        self.on_play_done(on_play_done)
 
     def _make_generator(self):
         """创建 audio generator，每次 yield 精确 frame_count 的字节。"""

--- a/src/ghoshell_moss/host/speech/volcengine_asr/recognizer.py
+++ b/src/ghoshell_moss/host/speech/volcengine_asr/recognizer.py
@@ -176,10 +176,9 @@ class VolcengineASR(ASR):
             data = json.loads(payload)
             text = data.get("result", {}).get("text", "")
             utterances = data.get("result", {}).get("utterances", [])
-            is_final = False
-            if utterances and len(utterances) > 0:
-                # definite 表示是一个确定的分句
-                is_final = bool(utterances[0].get("definite", False))
+            is_final = any(
+                bool(u.get("definite", False)) for u in utterances
+            )
             return ASRResult(text=text, is_final=is_final)
         except Exception as e:
             self._logger.warning(


### PR DESCRIPTION
- MiniAudioStreamPlayer: add transport wiring with debounced speaker AudioRuntimeTopic. Use threading.Timer to delay running=False until playback buffers actually drain, preventing per-chunk True→False flicker that made the gate invisible to the listener.
- AudioPlayerProvider: resolve Matrix from IoC and pass transport to player, completing the symmetric capture/playback topology.
- Listener: add _iter_with_silence_timeout() to break ASR recognition when the server sends empty keep-alive results but never finalizes (continuous ambient noise prevents VAD silence detection). Only non-empty results reset the timer.
- Listener: add post-utterance cooldown to give ghost time to start TTS before the next ASR session begins.
- Listener: suppress noisy speaker running=False gate logs.
- base_attention: remove duplicate _buffered_impulses.append() call.

coding by deepseek-v4-pro
via claude code