### PR TITLE
fix(zmq): use native RCVTIMEO and add socket-level reconnection by de…

### DIFF
--- a/src/ghoshell_moss/bridges/zmq_channel/zmq_channel.py
+++ b/src/ghoshell_moss/bridges/zmq_channel/zmq_channel.py
@@ -88,8 +88,19 @@ class BaseZMQConnection(Connection, ABC):
             return
         self._closed_event.set()
         if self._heartbeat_task:
-            await self._heartbeat_task
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except asyncio.CancelledError:
+                pass
             self._heartbeat_task = None
+
+        if self._socket is not None:
+            try:
+                self._socket.close(linger=self._config.linger)
+            except Exception:
+                pass
+            self._socket = None
 
         if self._config.is_ipc_address():
             # 对于 IPC 地址，需要手动删除 socket 文件
@@ -112,28 +123,46 @@ class BaseZMQConnection(Connection, ABC):
 
     async def start(self) -> None:
         """启动连接，创建并配置 socket"""
-        if self._socket is not None:
+        if self._socket is not None and not self._closed_event.is_set():
             return
+
+        # 清理旧 socket
+        if self._socket is not None:
+            try:
+                self._socket.close(linger=self._config.linger)
+            except Exception:
+                pass
+            self._socket = None
 
         # 创建 socket
         socket_type = getattr(zmq, self._config.socket_type.value)
-        self._socket = self._ctx.socket(socket_type)
+        sock = self._ctx.socket(socket_type)
 
         # 配置 socket
         if self._config.recv_timeout is not None:
-            self._socket.RCVTIMEO = int(self._config.recv_timeout * 1000)
-        if self._config.send_timeout is not None:
-            self._socket.SNDTIMEO = int(self._config.send_timeout * 1000)
-        if self._config.linger is not None:
-            self._socket.linger = self._config.linger
-        if self._config.identity is not None:
-            self._socket.identity = self._config.identity
-
-        # 绑定或连接
-        if self._config.bind:
-            self._socket.bind(self._config.address)
+            sock.RCVTIMEO = int(self._config.recv_timeout * 1000)
         else:
-            self._socket.connect(self._config.address)
+            sock.RCVTIMEO = 500  # 使用原生超时避免 task cancel 竞态
+        if self._config.send_timeout is not None:
+            sock.SNDTIMEO = int(self._config.send_timeout * 1000)
+        if self._config.linger is not None:
+            sock.linger = self._config.linger
+        if self._config.identity is not None:
+            sock.identity = self._config.identity
+
+        # 绑定或连接（失败时回滚，不污染状态）
+        try:
+            if self._config.bind:
+                sock.bind(self._config.address)
+            else:
+                sock.connect(self._config.address)
+        except Exception:
+            sock.close(linger=0)
+            raise
+
+        self._socket = sock
+        self._closed_event.clear()
+        self._last_activity = time.time()
 
         # 订阅主题（如果是 SUB socket）
         if self._config.socket_type == ZMQSocketType.SUB and self._config.subscribe is not None:
@@ -159,71 +188,31 @@ class BaseZMQConnection(Connection, ABC):
 
         async with self._recv_lock:
             while not self._closed_event.is_set():
+                # 检查调用方超时
+                if timeout is not None and time.time() - start_time >= timeout:
+                    raise asyncio.TimeoutError("Receive timeout")
+
                 try:
-                    # 计算剩余超时时间
-                    remaining_timeout = None
-                    if timeout is not None:
-                        elapsed = time.time() - start_time
-                        if elapsed >= timeout:
-                            raise asyncio.TimeoutError("Receive timeout")
-                        remaining_timeout = timeout - elapsed
-
-                    # 使用 asyncio.wait 同时等待接收操作和心跳检查
-                    receive_task = asyncio.ensure_future(self._socket.recv_json())
-                    tasks = [receive_task]
-                    check_remaining_task = None
-                    if remaining_timeout is not None:
-                        check_remaining_task = asyncio.create_task(asyncio.sleep(remaining_timeout))
-                        tasks.append(check_remaining_task)
-                    check_closed_task = asyncio.create_task(self._closed_event.wait())
-                    tasks.append(check_closed_task)
-
-                    # 等待第一个完成的任务
-                    done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-
-                    # 取消未完成的任务
-                    for task in pending:
-                        task.cancel()
-
-                    # 处理心跳超时
-                    if check_remaining_task in done:
-                        raise asyncio.TimeoutError("Receive timeout")
-                    elif check_closed_task in done:
-                        self._closed_event.set()
-                        raise ConnectionClosedError("Connection closed")
-                    # 处理接收到的消息
-                    else:
-                        message = await receive_task
-                        # 更新最后活动时间
-                        self._last_activity = time.time()
-
-                        # 处理心跳消息
-                        if message.get("event_type") == HeartbeatEvent.event_type:
-                            await self._handle_heartbeat(message)
-                            continue  # 继续等待有效消息
-
-                        return message
-
+                    message = await self._socket.recv_json()
                 except zmq.ZMQError as e:
                     if e.errno == zmq.ETERM:
                         raise ConnectionClosedError("Connection closed")
                     elif e.errno == zmq.EAGAIN:
-                        # 超时，检查是否因活动超时
+                        # ZMQ 原生超时 — 检查心跳
                         if not self._config.bind and time.time() - self._last_activity > self._config.heartbeat_timeout:
                             raise asyncio.TimeoutError("Heartbeat timeout")
-                        raise asyncio.TimeoutError("Receive timeout")
+                        continue
                     else:
                         raise
-                except asyncio.TimeoutError:
-                    # 检查是否因活动超时
-                    if not self._config.bind and time.time() - self._last_activity > self._config.heartbeat_timeout:
-                        raise asyncio.TimeoutError("Heartbeat timeout")
-                    raise
-                except Exception as e:
-                    # 检查是否因活动超时
-                    if not self._config.bind and time.time() - self._last_activity > self._config.heartbeat_timeout:
-                        raise asyncio.TimeoutError("Heartbeat timeout") from e
-                    raise
+
+                # 成功收到消息
+                self._last_activity = time.time()
+
+                if message.get("event_type") == HeartbeatEvent.event_type:
+                    await self._handle_heartbeat(message)
+                    continue
+
+                return message
 
     async def send(self, event: ChannelEvent) -> None:
         """发送消息"""

--- a/src/ghoshell_moss/core/duplex/proxy.py
+++ b/src/ghoshell_moss/core/duplex/proxy.py
@@ -356,17 +356,22 @@ class DuplexChannelContext:
                 await asyncio.sleep(0.0)
                 # 如果通讯失效了, 就清空连接状态, 等待重连.
                 if not self.connection.is_connected():
-                    # 如果在连接状态, 则要清空.
                     if self._connected_event.is_set():
-                        # 取消连接状态.
                         self._clear_connection_status()
-                        # 稍微等待下一轮.
-                        await asyncio.sleep(0.1)
                         self.logger.info("Channel proxy %s connection status cleared", self.root_name)
-                        continue
-                    else:
-                        # 已经设置过连接失败, 则直接跳到拉取消息即可.
+                    # 重置重连标记，确保 session 重建
+                    is_reconnected = False
+                    # 尝试 socket 级别重连
+                    try:
+                        await self.connection.close()
+                    except Exception:
                         pass
+                    try:
+                        await self.connection.start()
+                    except Exception:
+                        pass
+                    await asyncio.sleep(self._wait_reconnect_interval)
+                    continue
                 else:
                     if not is_reconnected:
                         # 发送初始化连接.  proxy 一定要发送至少第一次, 因为 provider

--- a/tests/ghoshell_moss/bridges/zmq_channel/test_zmq_channel.py
+++ b/tests/ghoshell_moss/bridges/zmq_channel/test_zmq_channel.py
@@ -5,7 +5,10 @@ import pytest
 
 from ghoshell_moss.core.concepts.command import CommandError
 from ghoshell_moss.core.py_channel import PyChannel
-from ghoshell_moss.bridges.zmq_channel.zmq_channel import ZMQSocketType, create_zmq_channel
+from ghoshell_moss.bridges.zmq_channel.zmq_channel import (
+    ZMQSocketType,
+    create_zmq_channel,
+)
 
 
 def get_random_port():
@@ -267,3 +270,72 @@ async def test_zmq_channel_multiple_commands():
     finally:
         provider.close()
         provider.wait_closed_sync()
+
+
+@pytest.mark.asyncio
+async def test_zmq_channel_reconnect_after_heartbeat_loss():
+    """测试心跳丢失后 proxy 在 socket 层面自动重连并恢复通讯。
+
+    模拟场景: 网络闪断导致心跳包有去无回，proxy 通过心跳超时检测到断连，
+    在 socket 层面 close + start 重建连接，然后重建 session，全程无需重启 provider。
+    """
+    port = get_random_port()
+    address = f"tcp://127.0.0.1:{port}"
+
+    provider, proxy = create_zmq_channel(
+        name="reconnect_test",
+        address=address,
+        heartbeat_interval=0.1,
+        heartbeat_timeout=0.3,
+    )
+
+    channel = PyChannel(name="provider")
+
+    @channel.build.command()
+    async def ping() -> str:
+        return "pong"
+
+    provider.run_in_thread(channel)
+
+    try:
+        async with proxy.bootstrap() as runtime:
+            await runtime.wait_connected()
+            assert runtime.is_connected()
+
+            cmd = runtime.get_command("ping")
+            assert await cmd() == "pong"
+
+            # 模拟心跳丢失: 拦截 provider 的心跳响应 handler，
+            # 让 proxy 发出的心跳请求有去无回，_last_activity 不再更新。
+            provider_conn = provider._connection
+
+            async def _drop_heartbeat(event):
+                pass
+
+            original_handler = provider_conn._handle_heartbeat
+            provider_conn._handle_heartbeat = _drop_heartbeat
+
+            # 等待 proxy 通过心跳超时检测到断连
+            for _ in range(30):
+                if not runtime.is_connected():
+                    break
+                await asyncio.sleep(0.1)
+            assert not runtime.is_connected(), "proxy 应通过心跳超时检测到断连"
+
+            # 恢复心跳 handler，让 provider 重新响应心跳
+            provider_conn._handle_heartbeat = original_handler
+
+            # 等待 proxy 完成 socket 级重连 + session 重建
+            for _ in range(50):
+                if runtime.is_connected():
+                    break
+                await asyncio.sleep(0.1)
+            assert runtime.is_connected(), "proxy 应自动重连成功"
+
+            # 验证重连后命令能正常执行（同一个 channel，同一个命令）
+            cmd = runtime.get_command("ping")
+            assert await cmd() == "pong"
+    finally:
+        if provider.is_running():
+            provider.close()
+            provider.wait_closed_sync()


### PR DESCRIPTION
…epseek-v4-pro

Replace unsafe asyncio task cancellation in recv() with ZMQ native RCVTIMEO to prevent message framing corruption. Add socket-level reconnection in DuplexChannelContext._main_receiving_loop(): when heartbeat fails, close the old socket, create a new one, and re-establish the session. Also fix close() to properly close the ZMQ socket and start() to allow restart.

via claude code