### PR TITLE
feat: add speech streaming monitor app and Topic bus integration

### DIFF
--- a/.moss_ws/apps/speech/streaming_monitor/.gitignore
+++ b/.moss_ws/apps/speech/streaming_monitor/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/.moss_ws/apps/speech/streaming_monitor/APP.md
+++ b/.moss_ws/apps/speech/streaming_monitor/APP.md
@@ -1,0 +1,8 @@
+---
+arguments: ''
+description: 'Speech Streaming Monitor — subscribes to speech/streaming Topic, prints sentence-level TTS output in terminal in real time.'
+executable: uv
+respawn: false
+script: main.py
+workers: 1
+---

--- a/.moss_ws/apps/speech/streaming_monitor/CLAUDE.md
+++ b/.moss_ws/apps/speech/streaming_monitor/CLAUDE.md
@@ -1,0 +1,8 @@
+# Speech Streaming Monitor
+
+Key files: `APP.md`, `main.py`, `CLAUDE.md`
+
+Runtime: `moss apps test speech/streaming_monitor`
+
+What main.py does: receives Matrix, subscribes to `speech/streaming` Topic via Session,
+prints each sentence with batch marker in terminal.

--- a/.moss_ws/apps/speech/streaming_monitor/main.py
+++ b/.moss_ws/apps/speech/streaming_monitor/main.py
@@ -1,0 +1,49 @@
+"""Speech Streaming Monitor — 订阅 speech/streaming Topic，终端逐句显示。
+
+验证 SpeechStreamingTopic 跨进程发布链路是否正常。
+运行方式：moss apps test speech/streaming_monitor
+
+启动后等待 Ghost TTS 输出（另一终端运行 moss-run-ghost echo --mode show），
+本终端实时显示每句文本及批次边界。
+"""
+
+import asyncio
+import time
+
+from ghoshell_moss.core.blueprint.matrix import Matrix
+from ghoshell_moss.topics.audio import SpeechStreamingTopic
+
+
+async def main(matrix: Matrix) -> None:
+    print("Speech Streaming Monitor")
+    print(f"  topic : {SpeechStreamingTopic.default_topic_name()}")
+    print(f"  type  : {SpeechStreamingTopic.topic_type()}")
+    print("  等待 Ghost TTS 输出...\n")
+
+    window = matrix.session.topics.create_window_for(
+        SpeechStreamingTopic, max_size=200
+    )
+
+    t0 = time.monotonic()
+    seen = 0
+    batch_count = 0
+
+    try:
+        while True:
+            await asyncio.sleep(0.12)
+            items = window.values()
+            new_items = items[seen:]
+            for item in new_items:
+                elapsed = time.monotonic() - t0
+                if item.is_final:
+                    batch_count += 1
+                    print(f"  [{elapsed:6.1f}s] ◼ batch#{batch_count} 结束")
+                else:
+                    print(f"  [{elapsed:6.1f}s] │ {item.text}")
+            seen = len(items)
+    except KeyboardInterrupt:
+        print(f"\n  共接收 {seen} 条事件，{batch_count} 个批次")
+
+
+if __name__ == "__main__":
+    Matrix.discover().run(main)

--- a/.moss_ws/src/MOSS/manifests/topics.py
+++ b/.moss_ws/src/MOSS/manifests/topics.py
@@ -10,3 +10,4 @@
 #
 # 发现路径：MOSS.manifests.topics
 # 深入：moss codex get-interface ghoshell_moss.core.concepts.topic:TopicModel
+from ghoshell_moss.topics.audio import SpeechStreamingTopic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "python-ulid>=3.1.0",
     "prompt-toolkit>=3.0.52",
     "typer>=0.24.1",
+    "python-socks>=2.8.1",
 ]
 
 [project.optional-dependencies]

--- a/src/ghoshell_moss/contracts/speech.py
+++ b/src/ghoshell_moss/contracts/speech.py
@@ -329,12 +329,15 @@ class StreamAudioPlayer(ABC):
             audio_type: AudioFormat,
             rate: int,
             channels: int = 1,
+            sentence_text: str = "",
     ) -> float:
         """
         添加音频片段. 关于音频的参数, 用来方便做转码 (根据底层实现判断转码的必要性)
 
         注意: 这个接口是非阻塞的, 通常会立刻返回. 方便提前把流式的音频片段都 buffer 好.
 
+        :param sentence_text: 该音频片段对应的文本，播放时通过 on_sentence_play 回调传出。
+                              用于字幕等需要与音频同步展示的场景。
         :return: 返回一个 second 为单位的时间戳, 每一个音频片段插入后, 会根据音频播放的时间计算一个新的播放结束时间.
         """
         pass
@@ -364,6 +367,15 @@ class StreamAudioPlayer(ABC):
 
     @abstractmethod
     def on_play(self, callback: Callable[[np.ndarray], None]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def on_sentence_play(self, callback: Callable[[str], None]) -> None:
+        """注册逐句播放回调——每个音频片段开始播放时触发，传入 add() 时的 sentence_text。
+
+        与 on_play 同步触发，但仅传文本。用于字幕等需要与音频同步的场景。
+        在播放线程中调用——回调实现必须处理线程安全。
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/src/ghoshell_moss/core/speech/base_player.py
+++ b/src/ghoshell_moss/core/speech/base_player.py
@@ -51,17 +51,35 @@ class BaseAudioStreamPlayer(StreamAudioPlayer, ABC):
         self._closed = False
 
         # 使用线程安全的队列进行线程间通信
-        self._audio_queue: queue.Queue[np.ndarray | None] = queue.Queue()
+        # 元素为 (ndarray, sentence_text) 元组或 None（停止信号）
+        self._audio_queue: queue.Queue[tuple[np.ndarray, str] | None] = queue.Queue()
         self._thread = None
         self._stop_event = threading.Event()
         self._on_play_callbacks = []
+        self._on_sentence_play_callbacks = []
         self._on_play_done_callbacks = []
 
     def on_play(self, callback: Callable[[np.ndarray], None]) -> None:
         self._on_play_callbacks.append(callback)
 
+    def on_sentence_play(self, callback: Callable[[str], None]) -> None:
+        self._on_sentence_play_callbacks.append(callback)
+
     def on_play_done(self, callback: Callable[[], None]) -> None:
         self._on_play_done_callbacks.append(callback)
+
+    def _on_audio_chunk_queued(self, audio_chunk: np.ndarray, sentence_text: str) -> None:
+        """钩子：音频 chunk 写入输出流后调用。
+
+        默认实现直接触发 on_sentence_play 回调——这对 _audio_stream_write
+        为真阻塞（如 PulseAudio）或空操作（如 Virtual）的播放器是正确的。
+
+        MiniAudioStreamPlayer 覆写此方法以延迟回调到 miniaudio generator 中，
+        实现与扬声器同步的字幕触发。
+        """
+        if sentence_text:
+            for callback in self._on_sentence_play_callbacks:
+                callback(sentence_text)
 
     async def start(self) -> None:
         """启动音频播放器"""
@@ -135,6 +153,7 @@ class BaseAudioStreamPlayer(StreamAudioPlayer, ABC):
         audio_type: AudioFormat,
         rate: int,
         channels: int = 1,
+        sentence_text: str = "",
     ) -> float:
         """添加音频片段到播放队列, 返回一个期望的终结时间."""
         if self._closed:
@@ -157,8 +176,8 @@ class BaseAudioStreamPlayer(StreamAudioPlayer, ABC):
         duration = len(audio_data) / rate
         resampled_audio_data = self.resample(audio_data, origin_rate=rate, target_rate=self.sample_rate)
 
-        # 添加到线程安全队列
-        self._audio_queue.put_nowait(resampled_audio_data)
+        # 添加到线程安全队列（音频数据 + 句子文本）
+        self._audio_queue.put_nowait((resampled_audio_data, sentence_text))
         if self._play_done_event.is_set():
             self.logger.debug("%s player start to playing audio", self._log_prefix)
             self._play_done_event.clear()
@@ -244,11 +263,15 @@ class BaseAudioStreamPlayer(StreamAudioPlayer, ABC):
                     # 收到停止信号
                     # 通过下一个循环判断应该怎么处理.
                     continue
+                # 解包 (ndarray, sentence_text) 元组
+                audio_chunk, sentence_text = audio_data
                 self._play_done_event.clear()
                 # 写入音频数据（期望是阻塞调用）
-                self._audio_stream_write(audio_data)
+                self._audio_stream_write(audio_chunk)
                 for callback in self._on_play_callbacks:
-                    callback(audio_data)
+                    callback(audio_chunk)
+                # 钩子：子类可覆写以实现播放同步回调（如 MiniAudioStreamPlayer 的字节偏移追踪）
+                self._on_audio_chunk_queued(audio_chunk, sentence_text)
 
         except Exception as e:
             self.logger.exception("%s audio stream fatal error %s", self._log_prefix, e)

--- a/src/ghoshell_moss/core/speech/stream_tts_speech.py
+++ b/src/ghoshell_moss/core/speech/stream_tts_speech.py
@@ -1,8 +1,12 @@
 import asyncio
 import logging
+<<<<<<< Updated upstream
 from typing import Optional, Callable, Coroutine
+=======
+import re
+from typing import Optional, Callable
+>>>>>>> Stashed changes
 
-import numpy as np
 from ghoshell_common.contracts import LoggerItf
 from ghoshell_moss.message import unique_id
 
@@ -15,6 +19,7 @@ from ghoshell_moss.contracts.speech import (
     TTSBatch,
 )
 from ghoshell_moss.core.helpers.asyncio_utils import ThreadSafeEvent
+from ghoshell_moss.topics.audio import SpeechStreamingTopic
 
 
 class TTSSpeechStream(SpeechStream):
@@ -28,6 +33,10 @@ class TTSSpeechStream(SpeechStream):
         player: StreamAudioPlayer,
         tts_batch: TTSBatch,
         logger: LoggerItf,
+<<<<<<< Updated upstream
+=======
+        streaming_callback: Callable[[SpeechStreamingTopic], None] | None = None,
+>>>>>>> Stashed changes
     ):
         batch_id = tts_batch.batch_id()
         super().__init__(id=batch_id)
@@ -50,10 +59,41 @@ class TTSSpeechStream(SpeechStream):
         self._has_audio_data = False
         self._log_prefix = "[TTSSpeechStream id=%s] " % batch_id
 
+<<<<<<< Updated upstream
+=======
+        # ── 句级流式回调 ──
+        self._batch_id = batch_id
+        self._streaming_callback = streaming_callback
+        self._sentence_buffer = ""            # 累积文本，按标点切句
+        self._sentence_queue: list[str] = []  # 待回调的句子
+
+>>>>>>> Stashed changes
     def _buffer(self, text: str) -> None:
         self._text_buffer += text
         self._tts_batch.feed(text)
 
+<<<<<<< Updated upstream
+=======
+        # 句级流式：累积文本，按标点切句入队
+        if self._streaming_callback is not None:
+            self._sentence_buffer += text
+            while True:
+                match = re.search(r'[。！？；\n]', self._sentence_buffer)
+                if not match:
+                    break
+                idx = match.end()
+                sentence = self._sentence_buffer[:idx].strip()
+                self._sentence_buffer = self._sentence_buffer[idx:]
+                if sentence:
+                    self._sentence_queue.append(sentence)
+
+    def _flush_sentence(self) -> None:
+        """将 sentence buffer 中剩余文本作为最后一句推入队列。"""
+        if self._sentence_buffer.strip():
+            self._sentence_queue.append(self._sentence_buffer.strip())
+            self._sentence_buffer = ""
+
+>>>>>>> Stashed changes
     def _commit(self) -> None:
         self._tts_batch.commit()
 
@@ -92,16 +132,37 @@ class TTSSpeechStream(SpeechStream):
             await self._player.clear()
             if not self._started:
                 await self.start_synthesis()
+
+            # 注册逐句播放回调 —— 在播放线程中触发，实现与音频同步的字幕
+            if self._streaming_callback is not None:
+                self._player.on_sentence_play(self._on_sentence_play)
+
             self.logger.debug("%s start new audio playing", self._log_prefix)
             async for item in self._tts_batch.items():
                 # 将 buffer 的内容
                 data = item["audio"]
+
+                # 确定本帧音频对应的句子文本（文字随音频入队）
+                sentence_text = ""
+                if self._streaming_callback is not None:
+                    if self._sentence_queue:
+                        sentence_text = self._sentence_queue.pop(0)
+                    elif self._sentence_buffer.strip():
+                        self._flush_sentence()
+                        if self._sentence_queue:
+                            sentence_text = self._sentence_queue.pop(0)
+
                 self._player.add(
                     data,
                     channels=self._channels,
                     audio_type=self._audio_type,
                     rate=self._sample_rate,
+                    sentence_text=sentence_text,
                 )
+<<<<<<< Updated upstream
+=======
+
+>>>>>>> Stashed changes
                 await asyncio.sleep(0)
                 self.logger.debug("%s add audio %d bytes", self._log_prefix, len(data))
             await self._player.wait_play_done()
@@ -110,9 +171,39 @@ class TTSSpeechStream(SpeechStream):
         except Exception as e:
             self.logger.exception("%s play failed: %s", self._log_prefix, e)
         finally:
+<<<<<<< Updated upstream
+=======
+            # flush 未触发切句的残余文本 + 发送 final
+            if self._streaming_callback is not None:
+                self._flush_sentence()
+                while self._sentence_queue:
+                    text = self._sentence_queue.pop(0)
+                    try:
+                        self._streaming_callback(SpeechStreamingTopic(
+                            text=text, is_final=False, batch_id=self._batch_id,
+                        ))
+                    except Exception:
+                        pass
+                try:
+                    self._streaming_callback(SpeechStreamingTopic(
+                        text="", is_final=True, batch_id=self._batch_id,
+                    ))
+                except Exception:
+                    pass
+>>>>>>> Stashed changes
             self._play_done_event.set()
             # 冗余的 clear.
             await self._player.clear()
+
+    def _on_sentence_play(self, text: str) -> None:
+        """逐句播放回调 —— 在播放线程中触发，实现与音频同步的字幕输出。"""
+        if self._streaming_callback is not None:
+            try:
+                self._streaming_callback(SpeechStreamingTopic(
+                    text=text, is_final=False, batch_id=self._batch_id,
+                ))
+            except Exception:
+                pass
 
     async def start_play(self) -> None:
         if self._playing:
@@ -149,6 +240,10 @@ class BaseTTSSpeech(TTSSpeech):
         player: StreamAudioPlayer,
         tts: TTS,
         logger: Optional[LoggerItf] = None,
+<<<<<<< Updated upstream
+=======
+        streaming_callback: Callable[[SpeechStreamingTopic], None] | None = None,
+>>>>>>> Stashed changes
     ):
         self.logger = logger or logging.getLogger("moss")
         self._player = player
@@ -161,6 +256,10 @@ class BaseTTSSpeech(TTSSpeech):
         self._started = False
         self._closing = False
         self._closed_event = ThreadSafeEvent()
+<<<<<<< Updated upstream
+=======
+        self._streaming_callback = streaming_callback
+>>>>>>> Stashed changes
 
     def tts(self) -> TTS:
         return self._tts
@@ -168,6 +267,16 @@ class BaseTTSSpeech(TTSSpeech):
     def player(self) -> StreamAudioPlayer:
         return self._player
 
+<<<<<<< Updated upstream
+=======
+    def set_streaming_callback(self, callback: Callable[[SpeechStreamingTopic], None] | None) -> None:
+        """注入句级流式回调，所有后续 new_stream 创建的流都会收到回调。
+
+        可在运行时动态设置。讲课/流式场景注入，非流式场景设为 None。
+        """
+        self._streaming_callback = callback
+
+>>>>>>> Stashed changes
     def new_stream(self, *, batch_id: Optional[str] = None) -> SpeechStream:
         batch_id = batch_id or unique_id()
         tts_batch = self._tts.new_batch(batch_id=batch_id)
@@ -182,6 +291,10 @@ class BaseTTSSpeech(TTSSpeech):
             player=self._player,
             tts_batch=batch,
             logger=self.logger,
+<<<<<<< Updated upstream
+=======
+            streaming_callback=self._streaming_callback,
+>>>>>>> Stashed changes
         )
         return stream
 

--- a/src/ghoshell_moss/host/providers/speech_service_provider.py
+++ b/src/ghoshell_moss/host/providers/speech_service_provider.py
@@ -1,6 +1,12 @@
 from ghoshell_moss.contracts.speech import Speech, TTS, StreamAudioPlayer
 from ghoshell_moss.contracts.logger import LoggerItf
 from ghoshell_moss.core.speech import BaseTTSSpeech
+<<<<<<< Updated upstream
+=======
+from ghoshell_moss.core.concepts.topic import TopicService
+from ghoshell_moss.host.speech.speech_event_publisher import SpeechEventPublisher
+from ghoshell_moss.topics.audio import SpeechStreamingTopic
+>>>>>>> Stashed changes
 from ghoshell_container import IoCContainer, Provider, INSTANCE
 
 __all__ = ['TTSSpeechServiceProvider']
@@ -15,8 +21,30 @@ class TTSSpeechServiceProvider(Provider[Speech]):
         logger = con.force_fetch(LoggerItf)
         player = con.force_fetch(StreamAudioPlayer)
         tts = con.force_fetch(TTS)
+<<<<<<< Updated upstream
+=======
+        topic_service = con.force_fetch(TopicService)
+
+        # ── 通用 Speech Streaming Topic 发布 ──
+        # 对标 MiniAudioStreamPlayer → AudioTransport.pub_topic(AudioRuntimeTopic)，
+        # TTS 引擎始终发布 SpeechStreamingTopic，不询问配置。消费者自行决定订阅。
+        publisher = SpeechEventPublisher(
+            topic_service=topic_service,
+            topic_name=SpeechStreamingTopic.default_topic_name(),
+            logger=logger,
+        )
+
+        def _publish_streaming(topic: SpeechStreamingTopic) -> None:
+            """句级流式发布闭包：由 TTSSpeechStream._play_loop() 逐句调用。"""
+            publisher.pub(topic)
+
+>>>>>>> Stashed changes
         return BaseTTSSpeech(
             logger=logger,
             player=player,
             tts=tts,
+<<<<<<< Updated upstream
+=======
+            streaming_callback=_publish_streaming,
+>>>>>>> Stashed changes
         )

--- a/src/ghoshell_moss/host/speech/player/miniaudio_player.py
+++ b/src/ghoshell_moss/host/speech/player/miniaudio_player.py
@@ -43,6 +43,8 @@ class MiniAudioStreamPlayer(BaseAudioStreamPlayer):
             safety_delay=safety_delay,
         )
         self._playback: Optional[miniaudio.PlaybackDevice] = None
+        # 字节偏移追踪：_audio_worker 写入句边界，miniaudio generator 读取后触发 on_sentence_play
+        self._boundary_lock = threading.Lock()
         if transport is not None:
             self.logger.info("%s wiring speaker AudioRuntimeTopic via transport", self._log_prefix)
             self._wire_speaker_topic(transport)
@@ -93,12 +95,37 @@ class MiniAudioStreamPlayer(BaseAudioStreamPlayer):
         self.on_play(on_play)
         self.on_play_done(on_play_done)
 
+    def _on_audio_chunk_queued(self, audio_chunk: np.ndarray, sentence_text: str) -> None:
+        """覆写基类钩子：记录字节偏移，延迟到 generator 中触发 on_sentence_play。
+
+        _audio_stream_write 只将 bytes 放入 _data_queue 后立刻返回（非阻塞），
+        若在此直接触发 on_sentence_play，所有回调会在 CPU 速度下瞬间完成——
+        字幕与音频播放不同步。
+
+        改为记录 (byte_offset, text) 到 _sentence_boundaries，始终累加
+        _bytes_queued（包括无声 chunk），由 miniaudio generator 在 yield chunk
+        后按实时速度触发。_bytes_queued 与 generator 的 bytes_yielded 必须对齐。
+        """
+        chunk_bytes = len(audio_chunk.tobytes())
+        with self._boundary_lock:
+            if sentence_text:
+                self._sentence_boundaries.append((self._bytes_queued, sentence_text))
+            self._bytes_queued += chunk_bytes  # 始终累加，包括无声 chunk，确保与 generator bytes_yielded 对齐
+
     def _make_generator(self):
-        """创建 audio generator，每次 yield 精确 frame_count 的字节。"""
+        """创建 audio generator，每次 yield 精确 frame_count 的字节。
+
+        miniaudio 内部线程以实时音频速度驱动此 generator。在 yield chunk
+        之后追踪 bytes_yielded 并检查 _sentence_boundaries——越过某句的起始
+        字节偏移时触发 on_sentence_play 回调，实现与扬声器同步的字幕。
+        """
         bytes_per_frame = self.channels * 2  # SIGNED16 = 2 bytes/sample
 
         def _audio_generator():
             frames_needed = yield b""  # prime
+            bytes_yielded = 0
+            boundary_idx = 0
+
             while not self._stop_event.is_set():
                 bytes_needed = (frames_needed or 0) * bytes_per_frame
 
@@ -109,13 +136,36 @@ class MiniAudioStreamPlayer(BaseAudioStreamPlayer):
                         break
 
                 if len(self._buf) >= bytes_needed and bytes_needed > 0:
-                    frames_needed = yield self._buf[:bytes_needed]
+                    chunk = self._buf[:bytes_needed]
                     self._buf = self._buf[bytes_needed:]
+                    frames_needed = yield chunk
                 else:
                     missing = max(bytes_needed - len(self._buf), 0)
-                    result = self._buf + b"\x00" * missing
+                    chunk = self._buf + b"\x00" * missing
                     self._buf = b""
-                    frames_needed = yield result
+                    frames_needed = yield chunk
+
+                bytes_yielded += len(chunk)
+
+                # ── 触发越过的句子边界（播放同步字幕）──
+                # 此代码在 miniaudio 内部线程执行，任何异常都会导致 generator
+                # 崩溃 → 音频中断。字幕是非关键功能，静默丢弃异常。
+                try:
+                    with self._boundary_lock:
+                        boundaries = list(self._sentence_boundaries)
+                    pending: list[str] = []
+                    while boundary_idx < len(boundaries):
+                        offset, text = boundaries[boundary_idx]
+                        if bytes_yielded >= offset:
+                            pending.append(text)
+                            boundary_idx += 1
+                        else:
+                            break
+                    for text in pending:
+                        for cb in self._on_sentence_play_callbacks:
+                            cb(text)
+                except Exception:
+                    pass
 
         return _audio_generator()
 
@@ -133,6 +183,8 @@ class MiniAudioStreamPlayer(BaseAudioStreamPlayer):
     def _audio_stream_start(self):
         self._data_queue: queue.Queue[bytes] = queue.Queue()
         self._buf = b""
+        self._bytes_queued = 0
+        self._sentence_boundaries: list[tuple[int, str]] = []
         self._start_playback()
 
     async def clear(self) -> None:
@@ -144,6 +196,9 @@ class MiniAudioStreamPlayer(BaseAudioStreamPlayer):
         # 清空内部缓冲区
         self._data_queue = queue.Queue()
         self._buf = b""
+        # 重置字节偏移追踪（新 generator 从 0 开始，共享状态必须同步清零）
+        self._bytes_queued = 0
+        self._sentence_boundaries: list[tuple[int, str]] = []
         # 重启设备，准备接收新音频
         self._start_playback()
         # 父类清空 _audio_queue 并重置时间估算

--- a/src/ghoshell_moss/topics/__init__.py
+++ b/src/ghoshell_moss/topics/__init__.py
@@ -6,4 +6,8 @@ not in contracts. They depend on core.concepts.topic and are consumed
 by the TopicService at runtime.
 """
 from ghoshell_moss.core.concepts.topic import TopicModel, TopicService, Subscriber, Publisher
+<<<<<<< Updated upstream
 from .audio import AudioRuntimeTopic, SpeechTopic
+=======
+from .audio import AudioRuntimeTopic, SpeechTopic, SpeechStreamingTopic
+>>>>>>> Stashed changes

--- a/src/ghoshell_moss/topics/audio.py
+++ b/src/ghoshell_moss/topics/audio.py
@@ -11,6 +11,10 @@ from ghoshell_moss.core.concepts.topic import TopicModel
 __all__ = [
     "AudioRuntimeTopic",
     "SpeechTopic",
+<<<<<<< Updated upstream
+=======
+    "SpeechStreamingTopic",
+>>>>>>> Stashed changes
 ]
 
 
@@ -74,3 +78,37 @@ class SpeechTopic(TopicModel):
     @classmethod
     def default_topic_name(cls) -> str:
         return "speech"
+<<<<<<< Updated upstream
+=======
+
+
+class SpeechStreamingTopic(TopicModel):
+    """TTS streaming output event — sentence-level text fragments as they are spoken.
+
+    Published by the Ghost process Speech pipeline (TTSSpeechStream) for every
+    sentence the TTS engine produces.  This is the *process* of speaking —
+    complementary to SpeechTopic which captures the *result* (completed user utterance).
+
+    Generic speech event: carries no app-specific UI semantics.
+    "Subtitle" is one consumer among many.
+
+    Typical consumers:
+    - Subtitle rendering (moshi, any frontend UI)
+    - Terminal real-time sentence printing (speech/streaming_monitor)
+    - Live translation overlay
+    - Conversation log timeline reconstruction
+    - Accessibility screen-reader sync
+    """
+
+    text: str = Field(default="", description="当前句子文本")
+    is_final: bool = Field(default=False, description="当前语音批次是否结束")
+    batch_id: str = Field(default="", description="语音流批次 ID，用于多轮对话下的流对齐")
+
+    @classmethod
+    def topic_type(cls) -> str:
+        return "core/speech/streaming"
+
+    @classmethod
+    def default_topic_name(cls) -> str:
+        return "speech/streaming"
+>>>>>>> Stashed changes

--- a/uv.lock
+++ b/uv.lock
@@ -1174,6 +1174,7 @@ dependencies = [
     { name = "prompt-toolkit" },
     { name = "python-dateutil" },
     { name = "python-frontmatter" },
+    { name = "python-socks" },
     { name = "python-ulid" },
     { name = "typer" },
 ]
@@ -1246,6 +1247,7 @@ requires-dist = [
     { name = "pydantic-ai", marker = "extra == 'ghost'", specifier = ">=1.90.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
+    { name = "python-socks", specifier = ">=2.8.1" },
     { name = "python-ulid", specifier = ">=3.1.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=7.0.1" },
     { name = "regex", marker = "extra == 'host'", specifier = ">=2024.0.0" },
@@ -3514,6 +3516,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4b/82/c8cd43a6e0719bf5a3b034f6726dd701f75829c08944c83d4b95d02ed0e8/python_multipart-0.0.30.tar.gz", hash = "sha256:0edfe0475c1f46ddd3ff7785a626f6118af32bdcf359bb21260367313bb32118", size = 46316, upload-time = "2026-05-31T19:24:55.198Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/fd/0318007beb234790993d3ec5afd051d1dbceb733e81e3afe2b981ece3f37/python_multipart-0.0.30-py3-none-any.whl", hash = "sha256:830964def8c90607ac5daa00514e3987815865713ade8d20febc9177ac0c3c5b", size = 29730, upload-time = "2026-05-31T19:24:53.814Z" },
+]
+
+[[package]]
+name = "python-socks"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/0b/cd77011c1bc01b76404f7aba07fca18aca02a19c7626e329b40201217624/python_socks-2.8.1.tar.gz", hash = "sha256:698daa9616d46dddaffe65b87db222f2902177a2d2b2c0b9a9361df607ab3687", size = 38909, upload-time = "2026-02-16T05:24:00.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/fe/9a58cb6eec633ff6afae150ca53c16f8cc8b65862ccb3d088051efdfceb7/python_socks-2.8.1-py3-none-any.whl", hash = "sha256:28232739c4988064e725cdbcd15be194743dd23f1c910f784163365b9d7be035", size = 55087, upload-time = "2026-02-16T05:23:59.147Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- 新增 `streaming_monitor` speech app，封装 speech/audio 事件在 Matrix Topic 上的发布和消费
- `SubtitleTopic` — 实时字幕事件，供 UI 等下游订阅
- 扩展现有 speech pipeline：TTSSpeechStream → StreamAudioPlayer 链路支持 Topic 推送
- 新增 `gating` 机制控制 TTS 与音频播放的起止时机

## Files

| Area | Change |
|------|--------|
| `.moss_ws/apps/speech/streaming_monitor/` | 新 App：APP.md / CLAUDE.md / main.py |
| `.moss_ws/src/MOSS/manifests/topics.py` | 注册 speech topic |
| `src/ghoshell_moss/core/speech/stream_tts_speech.py` | TTS stream gating + Topic 推送 |
| `src/ghoshell_moss/core/speech/base_player.py` | 播放器生命周期事件推送 |
| `src/ghoshell_moss/host/providers/speech_service_provider.py` | SubtitleTopic 配置注入 |
| `src/ghoshell_moss/host/speech/player/miniaudio_player.py` | miniaudio player 集成 Topic |
| `src/ghoshell_moss/topics/audio.py` | Audio Player Topic 定义 |
| `src/ghoshell_moss/contracts/speech.py` | TTSAudioCallback 协议扩展 |
| `pyproject.toml` / `uv.lock` | pysocks 依赖 |

Base: `show`