### PR TITLE
fix: clean up poisoned scopes in get_active_scope and commit_scope

### DIFF
--- a/src/ghoshell_moss/core/runtime/_base_channel_runtime.py
+++ b/src/ghoshell_moss/core/runtime/_base_channel_runtime.py
@@ -333,8 +333,19 @@ class AbsChannelRuntime(Generic[CHANNEL], ChannelRuntime, ABC):
     def get_active_scope(self, scope_id: str | None, pop: bool) -> ChannelScopeImpl | None:
         if scope_id is None:
             with self._channel_scope_change_lock:
+                while len(self._uncommitted_scopes) > 0:
+                    scope_id = self._uncommitted_scopes[-1]
+                    scope = self._channel_scopes.get(scope_id)
+                    if scope is not None and scope.is_closed():
+                        self._uncommitted_scopes.pop()
+                        self._channel_scopes.pop(scope_id, None)
+                        scope_id = None
+                    else:
+                        break
                 if len(self._uncommitted_scopes) > 0:
                     scope_id = self._uncommitted_scopes[-1]
+                else:
+                    scope_id = None
         if scope_id is None:
             return None
         if pop:
@@ -348,21 +359,27 @@ class AbsChannelRuntime(Generic[CHANNEL], ChannelRuntime, ABC):
             return self._channel_scopes.get(scope_id, None)
 
     def commit_scope(self, task: CommandTask) -> None:
-        scope_id = None
         with self._channel_scope_change_lock:
-            if len(self._uncommitted_scopes) > 0:
+            while len(self._uncommitted_scopes) > 0:
                 scope_id = self._uncommitted_scopes.pop()
-        if scope_id is None:
+                scope = self._channel_scopes.get(scope_id)
+                if scope is not None and scope.is_closed():
+                    self._channel_scopes.pop(scope_id, None)
+                    self._logger.info(
+                        "%s skip closed scope %s during commit",
+                        self.log_prefix, scope_id,
+                    )
+                    continue
+                break
+            else:
+                scope_id = None
+                scope = None
+        if scope_id is None or scope is None:
             task.cancel("Scope Closed")
             self._logger.info(
                 "%s failed to commit scope %s with task %s, cid=%s",
                 self.log_prefix, scope_id, task.caller_name(), task.cid,
             )
-            return
-        with self._channel_scope_change_lock:
-            scope = self._channel_scopes.get(scope_id, None)
-        if scope is None:
-            task.cancel("Scope Closed")
             return
         scope.commit(task)
         task.scope_id = scope.scope_id

--- a/tests/ghoshell_moss/default/core/runtime/test_scope_cleanup.py
+++ b/tests/ghoshell_moss/default/core/runtime/test_scope_cleanup.py
@@ -1,0 +1,168 @@
+"""
+Test: _uncommitted_scopes lifecycle — poisoned scope chain pollution.
+
+When _set_interpreter_error cancels a __scope_enter__ task whose scope has
+been opened but not yet committed, the scope's future is cancelled but the
+scope remains in _uncommitted_scopes, poisoning all subsequent scopes.
+"""
+import asyncio
+
+import pytest
+
+from ghoshell_moss.core.concepts.command import BaseCommandTask, CommandMeta
+from ghoshell_moss.core.concepts.errors import InterpretError
+from ghoshell_moss.core.py_channel import PyChannel
+from ghoshell_moss.core.ctml import new_ctml_shell
+
+
+@pytest.mark.asyncio
+async def test_append_interpreter_baseline():
+    """Verify kind='append' works for chaining interpreter sessions."""
+    channel = PyChannel(name="test")
+
+    got = []
+
+    @channel.build.command()
+    async def foo() -> int:
+        got.append(1)
+        return 123
+
+    shell = new_ctml_shell("test_shell")
+    shell.main_channel.import_channels(channel)
+
+    async with shell:
+        # Round 1: normal command
+        async with await shell.interpreter() as interpreter:
+            interpreter.feed("<test:foo />")
+            interpreter.commit()
+            tasks = await interpreter.wait_tasks()
+            interpreter.raise_exception()
+        assert len(got) == 1
+
+        # Round 2: append another command
+        async with await shell.interpreter(kind="append") as interpreter:
+            interpreter.feed("<test:foo />")
+            interpreter.commit()
+            tasks = await interpreter.wait_tasks()
+            interpreter.raise_exception()
+        assert len(got) == 2
+
+
+@pytest.mark.asyncio
+async def test_append_interpreter_with_scope_no_error():
+    """Verify kind='append' with a scope works without prior error."""
+    channel = PyChannel(name="test")
+
+    got = []
+
+    @channel.build.command()
+    async def foo() -> int:
+        got.append(1)
+        return 123
+
+    shell = new_ctml_shell("test_shell")
+    shell.main_channel.import_channels(channel)
+
+    async with shell:
+        # Round 1: scope with command
+        async with await shell.interpreter() as interpreter:
+            interpreter.feed("<_>hello<test:foo /></_>")
+            interpreter.commit()
+            await interpreter.wait_tasks()
+            interpreter.raise_exception()
+        assert len(got) == 1
+
+        # Round 2: append scope with command
+        async with await shell.interpreter(kind="append") as interpreter:
+            interpreter.feed("<_>hello<test:foo /></_>")
+            interpreter.commit()
+            await interpreter.wait_tasks()
+            interpreter.raise_exception()
+        assert len(got) == 2
+
+
+@pytest.mark.asyncio
+async def test_poisoned_scope_cancels_subsequent_scope():
+    """
+    Verify the fix: after a parse error poisons a scope, subsequent
+    append-interpreter scopes should still work correctly.
+
+    Round 1: parse error inside <_> leaves a poisoned (closed but
+    uncommitted) scope in the runtime.
+
+    Round 2 (kind='append'): a new <_> scope is opened. get_active_scope
+    cleans up the poisoned scope before returning, so the new scope is
+    created without being bound to a dead parent.
+
+    Result: the Round 2 foo command executes successfully.
+    """
+    channel = PyChannel(name="test")
+
+    got = []
+
+    @channel.build.command()
+    async def foo() -> int:
+        got.append(1)
+        return 123
+
+    shell = new_ctml_shell("test_shell")
+    shell.main_channel.import_channels(channel)
+
+    async with shell:
+        # Round 1: scope with text triggers enter task delivery via
+        # on_delta_token. Then <test:nonexistent /> triggers parse error
+        # which cancels the enter task via _set_interpreter_error.
+        # The scope is closed but stays in _uncommitted_scopes.
+        try:
+            async with await shell.interpreter() as interpreter:
+                interpreter.feed("<_><test:nonexistent /></_>")
+                interpreter.commit()
+                await interpreter.wait_tasks()
+                interpreter.raise_exception()
+        except InterpretError:
+            pass
+
+        # Round 2 (append): open a scope with a valid command inside.
+        # After fix: get_active_scope cleans up the poisoned scope from
+        # Round 1 before returning, so the new scope is NOT bound to a
+        # dead parent and foo executes successfully.
+        # Use until='all' so scope waits for cross-channel tasks (test:foo).
+        async with await shell.interpreter(kind="append") as interpreter:
+            interpreter.feed("<_ until='all'>hello<test:foo /></_>")
+            interpreter.commit()
+            tasks = await interpreter.wait_tasks()
+            interpreter.raise_exception()
+
+        # Verify no task was cancelled by poisoned scope
+        cancelled = [t for t in tasks.values() if t.cancelled()]
+        assert len(cancelled) == 0, (
+            f"BUG: {len(cancelled)} tasks cancelled by poisoned scope: "
+            f"{[t.caller_name() for t in cancelled]}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_healthy_scope_baseline():
+    """
+    Baseline: without a parse error, scope lifecycle should work normally.
+    """
+    channel = PyChannel(name="test")
+
+    got = []
+
+    @channel.build.command()
+    async def foo() -> int:
+        got.append(1)
+        return 123
+
+    shell = new_ctml_shell("test_shell")
+    shell.main_channel.import_channels(channel)
+
+    async with shell:
+        async with await shell.interpreter() as interpreter:
+            interpreter.feed("<_>hello<test:foo /></_>")
+            interpreter.commit()
+            await interpreter.wait_tasks()
+            interpreter.raise_exception()
+
+        assert len(got) == 1


### PR DESCRIPTION
## Summary                                                                                                                                                           
                                                                                                                                                                       
  修复 CTML 解析异常导致 "中毒 scope" 残留在 `_uncommitted_scopes` 中，污染后续所有 interpreter round 的 bug。                                                         
                                                                                                                                                                       
  ## Root Cause                                                                                                                                                        
                  
  CTML 解析抛出 `InterpretError` 时，`_set_interpreter_error` 取消所有 managing tasks，包括 `__scope_enter__`。Enter task 的 done                                      
  callback（`_on_enter_and_exit_task_done_check`）检测到取消后调用 `scope.close()`，resolve 了 scope 的 `_future`。但 `commit_scope` 从未被调用（因为 `_stopped_event`
  已被设置，`__scope_exit__` task 被丢弃），导致已关闭的 scope 残留在 `_uncommitted_scopes` 栈中。                                                                     
                  
  后续 interpreter（尤其是 `kind="append"`）的 `get_active_scope` 会返回这个中毒 scope。新 scope 被绑定为它的子 scope，新 task 被 `_on_scope_close_clear_sub_task`（已 
  resolve 的 `_future` 上的 done callback）立即取消。
                                                                                                                                                                       
  ## Fix          

  **`get_active_scope`**：返回栈顶 scope 前，循环检查 `is_closed()`。如果已关闭，从 `_uncommitted_scopes` 和 `_channel_scopes` 中移除，继续查找下一个。                
   
  **`commit_scope`**：从 `_uncommitted_scopes` pop 时跳过并清理已关闭的 scope。                                                                                        
                  
  所有操作在 `_channel_scope_change_lock` 内，仅当 `is_closed()` 为 True 时才移除——对正常 scope 生命周期无影响。                                                       
                  
  ## Test                                                                                                                                                              
                  
  4 个新测试（`tests/.../test_scope_cleanup.py`）：                                                                                                                    
  - `test_append_interpreter_baseline` — `kind='append'` 基础场景
  - `test_append_interpreter_with_scope_no_error` — 无错误时 append + scope                                                                                            
  - `test_poisoned_scope_cancels_subsequent_scope` — **核心 bug 复现**                                                                                                 
  - `test_healthy_scope_baseline` — 正常 scope 生命周期                                                                                                                
                                                                                                                                                                       
  全量测试 1882 passed，2 个预先存在的 flaky tests（与本次修改无关）。                                                                                                 
                                                                                                                                                                       
  ## Reproducer                                                                                                                                                        
                  
  \```python                                                                                                                                                           
  @pytest.mark.asyncio
  async def test_poisoned_scope_cancels_subsequent_scope():                                                                                                            
      channel = PyChannel(name="test")                                                                                                                                 
      got = []                                                                                                                                                         
                                                                                                                                                                       
      @channel.build.command()                                                                                                                                         
      async def foo() -> int:
          got.append(1)                                                                                                                                                
          return 123                                                                                                                                                   
                                                                                                                                                                       
      shell = new_ctml_shell("test_shell")                                                                                                                             
      shell.main_channel.import_channels(channel)                                                                                                                      
                                                                                                                                                                       
      async with shell:                                                                                                                                                
          # Round 1: 解析错误导致 scope 中毒                                                                                                                           
          try:                                                                                                                                                         
              async with await shell.interpreter() as interpreter:
                  interpreter.feed("<_>hello<test:nonexistent /></_>")                                                                                                 
                  interpreter.commit()                                                                                                                                 
                  await interpreter.wait_tasks()                                                                                                                       
                  interpreter.raise_exception()                                                                                                                        
          except InterpretError:                                                                                                                                       
              pass                                                                                                                                                     
                                                                                                                                                                       
          # Round 2: append 后应正常工作                                                                                                                               
          async with await shell.interpreter(kind="append") as interpreter:                                                                                            
              interpreter.feed("<_ until='all'>hello<test:foo /></_>")                                                                                                 
              interpreter.commit()                                                                                                                                     
              tasks = await interpreter.wait_tasks()                                                                                                                   
              interpreter.raise_exception()                                                                                                                            
                                                                                                                                                                       
          cancelled = [t for t in tasks.values() if t.cancelled()]                                                                                                     
          assert len(cancelled) == 0                                                                                                                                   
  \```                                                                                                                                                                 
                                                                                                                                                                       
  via claude code                                                                                                                                                      
                                                                                                                                                                       
  Changes: src/ghoshell_moss/core/runtime/_base_channel_runtime.py (+25, -8)                                                                                           
  Branch: fix/poisoned-scope-cleanup